### PR TITLE
User-scoped credentials with run_file injection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,12 @@ services:
       # to point local dev at cloud Langfuse instead.
       LANGFUSE_BASE_URL: ${LANGFUSE_BASE_URL:-http://langfuse-web:3000}
       LANGFUSE_TRACING_ENVIRONMENT: ${LANGFUSE_TRACING_ENVIRONMENT:-development}
+      # Fernet key (32-byte urlsafe base64) for encrypting user credentials
+      # at rest. Generate with:
+      #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+      # When unset the credentials feature is disabled and credential API
+      # routes return 503.
+      CREDENTIAL_ENCRYPTION_KEY: ${CREDENTIAL_ENCRYPTION_KEY:-}
     depends_on:
       - keycloak
       - sheerwater-mcp

--- a/frontend/src/widgets/chat.ts
+++ b/frontend/src/widgets/chat.ts
@@ -383,6 +383,30 @@ export class ChatWidget extends Widget {
         }
     }
 
+    private _escapeHtml(str: string): string {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+
+    /** Pull the flat list of secret names referenced by a credentials
+     *  argument (a list of materialization plans). Mirrors the server-side
+     *  `_collect_referenced_names`: both `env_vars` and `file` kinds carry
+     *  an explicit `names` list, so this is just the deduplicated union. */
+    private _collectCredentialNames(credentials: any): string[] {
+        if (!Array.isArray(credentials)) return [];
+        const out = new Set<string>();
+        for (const m of credentials) {
+            if (!m || typeof m !== 'object') continue;
+            if (Array.isArray(m.names)) {
+                for (const n of m.names) {
+                    if (typeof n === 'string' && n) out.add(n);
+                }
+            }
+        }
+        return Array.from(out);
+    }
+
     private _renderInterruptCard(interruptData: any): void {
         const card = document.createElement('div');
         card.className = 'interrupt-card';
@@ -395,9 +419,21 @@ export class ChatWidget extends Widget {
             ? (actionRequests[0].args || actionRequests[0].action?.args || {})
             : {};
 
+        // Walk the credentials materialization plans (if any) and collect
+        // every secret name they reference, so the user can see exactly
+        // which credentials this run will access before approving.
+        const accessedNames = this._collectCredentialNames(toolArgs.credentials);
+        const credentialsBlock = accessedNames.length > 0
+            ? `<div class="interrupt-credentials">
+                   <div class="interrupt-credentials-header">This run will access:</div>
+                   <ul>${accessedNames.map(n => `<li><code>${this._escapeHtml(n)}</code></li>`).join('')}</ul>
+               </div>`
+            : '';
+
         card.innerHTML = `
             <div class="interrupt-header">Approval Required</div>
             <div class="interrupt-tool">${toolName}</div>
+            ${credentialsBlock}
             <details class="interrupt-args">
                 <summary>arguments</summary>
                 <pre>${JSON.stringify(toolArgs, null, 2)}</pre>

--- a/frontend/src/widgets/config.ts
+++ b/frontend/src/widgets/config.ts
@@ -27,6 +27,9 @@ export class ConfigWidget extends Widget {
     private _skills: any[] = [];
     private _mcpList!: HTMLDivElement;
     private _mcpServers: any[] = [];
+    private _credentialList!: HTMLDivElement;
+    private _credentials: any[] = [];
+    private _credentialsDisabled = false;
 
     constructor() {
         super();
@@ -115,6 +118,22 @@ export class ConfigWidget extends Widget {
         addMcpBtn.addEventListener('click', () => this._showNewMcpModal());
         sidebar.appendChild(addMcpBtn);
 
+        const credentialsTitle = document.createElement('h3');
+        credentialsTitle.className = 'config-sidebar-title';
+        credentialsTitle.style.marginTop = '1.5rem';
+        credentialsTitle.textContent = 'Credentials';
+        sidebar.appendChild(credentialsTitle);
+
+        this._credentialList = document.createElement('div');
+        this._credentialList.className = 'vectorstore-list';
+        sidebar.appendChild(this._credentialList);
+
+        const addCredentialBtn = document.createElement('button');
+        addCredentialBtn.className = 'config-btn';
+        addCredentialBtn.textContent = '+ Add Credential';
+        addCredentialBtn.addEventListener('click', () => this._showNewCredentialForm());
+        sidebar.appendChild(addCredentialBtn);
+
         const settingsTitle = document.createElement('h3');
         settingsTitle.className = 'config-sidebar-title';
         settingsTitle.style.marginTop = '1.5rem';
@@ -165,7 +184,13 @@ export class ConfigWidget extends Widget {
     }
 
     private async _loadAgents(): Promise<void> {
-        await Promise.all([this._loadToolTypes(), this._loadVectorStores(), this._loadSkills(), this._loadMcpServers()]);
+        await Promise.all([
+            this._loadToolTypes(),
+            this._loadVectorStores(),
+            this._loadSkills(),
+            this._loadMcpServers(),
+            this._loadCredentials(),
+        ]);
         const res = await fetch('/api/agents');
         if (!res.ok) return;
         this._agents = await res.json();
@@ -801,5 +826,165 @@ export class ConfigWidget extends Widget {
         await this._loadMcpServers();
         await this._loadToolTypes();
         if (this._selectedAgentId) this._selectAgent(this._selectedAgentId);
+    }
+
+    // --- Credentials ---
+
+    private async _loadCredentials(): Promise<void> {
+        const res = await fetch('/api/credentials');
+        if (res.status === 503) {
+            this._credentials = [];
+            this._credentialsDisabled = true;
+            this._renderCredentialList();
+            return;
+        }
+        if (!res.ok) return;
+        this._credentials = await res.json();
+        this._credentialsDisabled = false;
+        this._renderCredentialList();
+    }
+
+    private _renderCredentialList(): void {
+        this._credentialList.innerHTML = '';
+        if (this._credentialsDisabled) {
+            const note = document.createElement('div');
+            note.className = 'vs-list-info';
+            note.style.color = 'var(--text-secondary)';
+            note.style.fontSize = '0.8rem';
+            note.style.padding = '0.25rem';
+            note.textContent = 'Disabled — set CREDENTIAL_ENCRYPTION_KEY to enable';
+            this._credentialList.appendChild(note);
+            return;
+        }
+        for (const cred of this._credentials) {
+            const item = document.createElement('div');
+            item.className = 'vs-list-item';
+
+            const info = document.createElement('div');
+            info.className = 'vs-list-info';
+            const name = document.createElement('span');
+            name.className = 'vs-list-name';
+            name.textContent = cred.name;
+            info.appendChild(name);
+            item.appendChild(info);
+
+            const actions = document.createElement('div');
+            actions.className = 'vs-list-actions';
+
+            const editBtn = document.createElement('button');
+            editBtn.className = 'config-btn-sm';
+            editBtn.textContent = 'Edit';
+            editBtn.addEventListener('click', () => this._showEditCredentialForm(cred));
+            actions.appendChild(editBtn);
+
+            const delBtn = document.createElement('button');
+            delBtn.className = 'config-btn-sm config-btn-danger';
+            delBtn.textContent = '\u00d7';
+            delBtn.title = 'Delete';
+            delBtn.addEventListener('click', () => this._deleteCredential(cred));
+            actions.appendChild(delBtn);
+
+            item.appendChild(actions);
+            this._credentialList.appendChild(item);
+        }
+    }
+
+    private _showNewCredentialForm(): void {
+        if (this._credentialsDisabled) {
+            alert('Credentials feature is disabled. Set CREDENTIAL_ENCRYPTION_KEY to enable.');
+            return;
+        }
+        this._detail.innerHTML = `
+            <div class="config-form">
+                <h2>Add Credential</h2>
+                <p style="color: var(--text-secondary); font-size: 0.85rem; margin-top: -0.5rem;">
+                    Stored encrypted. The value is never displayed back to you and never visible to the language model.
+                </p>
+                <div class="form-group">
+                    <label for="cred-name">Name</label>
+                    <input type="text" id="cred-name" placeholder="e.g. NASA_USERNAME">
+                </div>
+                <div class="form-group">
+                    <label for="cred-value">Value</label>
+                    <input type="password" id="cred-value">
+                </div>
+                <div class="config-form-actions">
+                    <button id="cancel-cred-btn" class="config-btn">Cancel</button>
+                    <button id="save-cred-btn" class="config-btn config-btn-primary">Save</button>
+                </div>
+            </div>
+        `;
+        this._detail.querySelector('#cancel-cred-btn')!.addEventListener('click', () => this._renderPlaceholder());
+        this._detail.querySelector('#save-cred-btn')!.addEventListener('click', async () => {
+            const name = (this._detail.querySelector('#cred-name') as HTMLInputElement).value.trim();
+            const value = (this._detail.querySelector('#cred-value') as HTMLInputElement).value;
+            if (!name || !value) return;
+            const res = await fetch('/api/credentials', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, value }),
+            });
+            if (!res.ok) {
+                const err = await res.json();
+                alert(err.detail || 'Save failed');
+                return;
+            }
+            await this._loadCredentials();
+            this._renderPlaceholder();
+        });
+    }
+
+    private _showEditCredentialForm(cred: any): void {
+        this._detail.innerHTML = `
+            <div class="config-form">
+                <h2>Edit Credential</h2>
+                <p style="color: var(--text-secondary); font-size: 0.85rem; margin-top: -0.5rem;">
+                    Stored values are not displayed. Leave the value blank to keep it, or type a new one to replace it.
+                </p>
+                <div class="form-group">
+                    <label for="cred-name">Name</label>
+                    <input type="text" id="cred-name" value="${escapeAttr(cred.name)}">
+                </div>
+                <div class="form-group">
+                    <label for="cred-value">Value</label>
+                    <input type="password" id="cred-value" placeholder="(unchanged)">
+                </div>
+                <div class="config-form-actions">
+                    <button id="cancel-cred-btn" class="config-btn">Cancel</button>
+                    <button id="save-cred-btn" class="config-btn config-btn-primary">Save</button>
+                </div>
+            </div>
+        `;
+        this._detail.querySelector('#cancel-cred-btn')!.addEventListener('click', () => this._renderPlaceholder());
+        this._detail.querySelector('#save-cred-btn')!.addEventListener('click', async () => {
+            const name = (this._detail.querySelector('#cred-name') as HTMLInputElement).value.trim();
+            const value = (this._detail.querySelector('#cred-value') as HTMLInputElement).value;
+            const body: any = {};
+            if (name && name !== cred.name) body.name = name;
+            if (value) body.value = value;
+            if (Object.keys(body).length === 0) {
+                this._renderPlaceholder();
+                return;
+            }
+            const res = await fetch(`/api/credentials/${cred.id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            if (!res.ok) {
+                const err = await res.json();
+                alert(err.detail || 'Save failed');
+                return;
+            }
+            await this._loadCredentials();
+            this._renderPlaceholder();
+        });
+    }
+
+    private async _deleteCredential(cred: any): Promise<void> {
+        if (!confirm(`Delete credential "${cred.name}"?`)) return;
+        const res = await fetch(`/api/credentials/${cred.id}`, { method: 'DELETE' });
+        if (!res.ok) return;
+        await this._loadCredentials();
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     # YAML parsing (SKILL.md frontmatter)
     "pyyaml>=6.0",
     "langfuse>=4.0.6",
+    "cryptography>=46.0.5",
 ]
 
 [project.optional-dependencies]

--- a/src/rhiza_agents/agents/graph.py
+++ b/src/rhiza_agents/agents/graph.py
@@ -106,12 +106,16 @@ def _config_hash(
     configs: list[AgentConfig],
     mcp_server_ids: list[str] | None = None,
     skill_ids: list[str] | None = None,
+    user_id: str | None = None,
+    credential_names: list[str] | None = None,
 ) -> str:
     data = json.dumps(
         {
             "configs": [c.model_dump() for c in configs],
             "mcp_servers": sorted(mcp_server_ids or []),
             "skills": sorted(skill_ids or []),
+            "user_id": user_id,
+            "credentials": sorted(credential_names or []),
         },
         sort_keys=True,
     )
@@ -151,14 +155,14 @@ async def _resolve_tools(
             else:
                 logger.info("Skill %s not loaded, skipping", skill_id)
         elif tool_id == "sandbox:daytona":
-            from .tools.files import run_file, write_file
-            from .tools.sandbox import execute_python_code, is_sandbox_available
+            from .tools.files import make_run_file, write_file
+            from .tools.sandbox import is_sandbox_available, make_execute_python_code
 
             # File tools are always available (write to state, not sandbox)
             tools.append(write_file)
             if is_sandbox_available():
-                tools.append(execute_python_code)
-                tools.append(run_file)
+                tools.append(make_execute_python_code(db=db))
+                tools.append(make_run_file(db=db))
             # If no API key, silently skip sandbox tools -- agent works without them
         else:
             logger.info("Tool type %s not yet implemented, skipping", tool_id)
@@ -191,6 +195,7 @@ async def build_graph(
     mcp_tools_by_server: dict[str, list] | None = None,
     mcp_server_names: dict[str, str] | None = None,
     skill_tools: dict | None = None,
+    user_id: str | None = None,
 ):
     """Build a compiled LangGraph StateGraph from AgentConfig objects."""
     supervisor_config = None
@@ -217,6 +222,18 @@ async def build_graph(
         vectorstore_manager is not None,
     )
 
+    # Load the user's available credential names so each worker that has
+    # the sandbox tool can be told what's available. Names only — never
+    # values. The list is captured at graph build time; the graph cache
+    # already invalidates when configs change, and the credentials route
+    # invalidates when secrets are added/removed.
+    credential_names: list[str] = []
+    if user_id and db is not None:
+        try:
+            credential_names = await db.list_credential_names(user_id)
+        except Exception:  # pragma: no cover - DB errors logged elsewhere
+            logger.warning("Failed to load credential names for user %s", user_id, exc_info=True)
+
     worker_agents = []
     agent_tool_descriptions = []
     for wc in worker_configs:
@@ -227,10 +244,25 @@ async def build_graph(
             max_tokens=16000,
             thinking={"type": "enabled", "budget_tokens": 10000},
         )
+
+        # Augment the worker's system prompt with available credential
+        # names if it has the sandbox tool. The LLM uses these names to
+        # populate the `credentials` argument of execute_python_code.
+        worker_prompt = wc.system_prompt
+        has_sandbox_tool = any(getattr(t, "name", None) == "execute_python_code" for t in tools)
+        if has_sandbox_tool and credential_names:
+            worker_prompt += (
+                "\n\nAvailable credential names (values are never visible to you):\n"
+                + "\n".join(f"  - {n}" for n in credential_names)
+                + "\n\nWhen calling execute_python_code, reference these names in the"
+                " `credentials` argument to make values available to the script. Never"
+                " print, log, echo, or otherwise expose credential values."
+            )
+
         worker = create_agent(
             model,
             tools,
-            system_prompt=wc.system_prompt,
+            system_prompt=worker_prompt,
             middleware=middleware,
             name=wc.id,
             state_schema=AgentGraphState,
@@ -308,9 +340,29 @@ async def get_or_build_graph(
     mcp_tools_by_server: dict[str, list] | None = None,
     mcp_server_names: dict[str, str] | None = None,
     skill_tools: dict | None = None,
+    user_id: str | None = None,
 ):
-    """Get a cached graph or build a new one."""
-    h = _config_hash(configs, list((mcp_tools_by_server or {}).keys()), list((skill_tools or {}).keys()))
+    """Get a cached graph or build a new one.
+
+    The cache key includes the user_id and the user's current set of
+    credential names so that adding/removing a credential transparently
+    rebuilds the affected user's graph (the new credential name needs to
+    appear in the worker system prompt).
+    """
+    credential_names: list[str] = []
+    if user_id and db is not None:
+        try:
+            credential_names = await db.list_credential_names(user_id)
+        except Exception:  # pragma: no cover
+            credential_names = []
+
+    h = _config_hash(
+        configs,
+        list((mcp_tools_by_server or {}).keys()),
+        list((skill_tools or {}).keys()),
+        user_id=user_id,
+        credential_names=credential_names,
+    )
     if h not in _graph_cache:
         _graph_cache[h] = await build_graph(
             configs,
@@ -321,6 +373,7 @@ async def get_or_build_graph(
             mcp_tools_by_server,
             mcp_server_names,
             skill_tools,
+            user_id=user_id,
         )
     return _graph_cache[h]
 

--- a/src/rhiza_agents/agents/registry.py
+++ b/src/rhiza_agents/agents/registry.py
@@ -53,19 +53,27 @@ for your code. Do not re-research or re-gather data that has already been provid
 
 You have three code tools: write_file, run_file, and execute_python_code.
 
-**For any non-trivial code (more than a few lines):** Always use write_file to \
-save the code as a script, then run_file to execute it. This lets the user review \
-the code before execution.
+**For any non-trivial code:** Always use write_file to save the script, then \
+run_file to execute it. This lets the user review the code before execution.
 
-**CRITICAL: If you have already written a script with write_file, you MUST use \
-run_file to execute it. NEVER use execute_python_code to run code that duplicates \
-or replaces a script you already wrote.** The user reviews the written file — \
-running different code via execute_python_code bypasses that review and is a \
-security violation.
+**CRITICAL: scripts MUST go through write_file → run_file. NEVER use \
+execute_python_code to run a script body — not by inlining the code, not by \
+calling exec(open(...)), not by importing the script, not by any other \
+workaround.** If you already wrote a file, you MUST use run_file to execute \
+it. The user reviews the written file; running different code via \
+execute_python_code bypasses that review and is a security violation.
 
-**execute_python_code is ONLY for:** quick one-off commands like pip installs, \
-checking file sizes, printing environment info, or other short exploratory \
-commands that are not the main task.
+**run_file and execute_python_code BOTH support the same `credentials` \
+argument.** If a script needs stored secrets, pass the credentials to \
+run_file — there is never a reason to switch to execute_python_code just to \
+get credentials. Both tools resolve credentials identically.
+
+**execute_python_code is ONLY for** quick one-off commands like checking \
+file sizes, listing a directory, printing environment info, or other short \
+exploratory commands that are not the main task. Do not install packages \
+with pip — declare dependencies via PEP 723 inline script metadata in the \
+file you write_file, and run_file will resolve them automatically with \
+`uv run`.
 
 ## Sandbox environment
 

--- a/src/rhiza_agents/agents/supervisor.py
+++ b/src/rhiza_agents/agents/supervisor.py
@@ -45,4 +45,5 @@ async def get_agent_graph(
         mcp_tools_by_server,
         mcp_server_names,
         skill_tools,
+        user_id=user_id,
     )

--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -11,7 +11,11 @@ from langgraph.prebuilt import ToolRuntime
 from langgraph.types import Command
 
 from ...credentials import redact_output
-from .sandbox import _BINARY_EXTENSIONS, resolve_credentials_or_error
+from .sandbox import (
+    _BINARY_EXTENSIONS,
+    _normalize_sandbox_upload_path,
+    resolve_credentials_or_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -185,10 +189,16 @@ def make_run_file(db=None):
             sandbox = _get_or_create_sandbox(thread_id)
 
             # Apply file materializations (e.g. ~/.netrc) before running.
-            # Always 0600 — these are credential files.
+            # Always 0600 — these are credential files. Daytona's
+            # ``fs.upload_file`` signature is (content_bytes, remote_path),
+            # and remote_path is resolved against the sandbox's working
+            # directory and does NOT expand ``~``, so the path is
+            # normalized first; the chmod still uses the original logical
+            # path because it runs in a shell that expands ``~``.
             for cred_path, content in file_uploads.items():
+                upload_path = _normalize_sandbox_upload_path(cred_path)
                 try:
-                    sandbox.fs.upload_file(cred_path, content.encode("utf-8"))
+                    sandbox.fs.upload_file(content.encode("utf-8"), upload_path)
                 except Exception:
                     logger.warning("Failed to upload credential file %s", cred_path, exc_info=True)
                 try:
@@ -197,7 +207,7 @@ def make_run_file(db=None):
                     pass
 
             # Write the script itself to the sandbox.
-            filename = path.lstrip("/")
+            filename = _normalize_sandbox_upload_path(path)
             sandbox.fs.upload_file(code.encode("utf-8"), filename)
 
             # Snapshot files after upload but before execution to detect new output files

--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -10,7 +10,8 @@ from langchain_core.tools import tool
 from langgraph.prebuilt import ToolRuntime
 from langgraph.types import Command
 
-from .sandbox import _BINARY_EXTENSIONS
+from ...credentials import redact_output
+from .sandbox import _BINARY_EXTENSIONS, resolve_credentials_or_error
 
 logger = logging.getLogger(__name__)
 
@@ -75,149 +76,224 @@ async def write_file(
     )
 
 
-@tool
-async def run_file(
-    path: str,
-    *,
-    runtime: ToolRuntime,
-) -> Command:
-    """Execute a Python file from the conversation's virtual filesystem in the sandbox.
+def make_run_file(db=None):
+    """Build the ``run_file`` tool with credential support.
 
-    Reads the file content from state and runs it in the code sandbox.
-    The file must already exist (written via write_file).
-
-    Args:
-        path: Path of the file to execute (e.g., '/code/analysis.py').
+    Like ``make_execute_python_code``, this is a factory because the tool
+    needs the application database to resolve stored credentials at run
+    time. The two tools share their credential semantics via
+    ``resolve_credentials_or_error`` so the LLM sees consistent behavior.
     """
-    if not path.startswith("/"):
-        path = "/" + path
 
-    files = runtime.state.get("files", {})
-    file_data = files.get(path)
-    if not file_data:
-        return Command(
-            update={
-                "messages": [
-                    ToolMessage(
-                        content=f"Error: File not found: {path}",
-                        tool_call_id=runtime.tool_call_id,
-                    )
-                ],
-            }
-        )
+    @tool
+    async def run_file(
+        path: str,
+        credentials: list[dict] | None = None,
+        *,
+        runtime: ToolRuntime,
+    ) -> Command:
+        """Execute a Python file from the conversation's virtual filesystem in the sandbox.
 
-    content_lines = file_data.get("content", [])
-    code = "\n".join(content_lines)
+        Reads the file content from state and runs it in the code sandbox
+        via ``uv run`` (which honors PEP 723 inline script dependencies).
+        The file must already exist (written via ``write_file``).
 
-    if not code.strip():
-        return Command(
-            update={
-                "messages": [
-                    ToolMessage(
-                        content=f"Error: File is empty: {path}",
-                        tool_call_id=runtime.tool_call_id,
-                    )
-                ],
-            }
-        )
+        This is the preferred way to run any non-trivial code that the user
+        should be able to review. Always go through ``write_file`` →
+        ``run_file`` for scripts; never use ``execute_python_code`` to run
+        code that lives in (or could live in) a file.
 
-    from .sandbox import _get_or_create_sandbox, is_sandbox_available
+        Args:
+            path: Path of the file to execute (e.g., '/code/analysis.py').
+            credentials: Optional list of materialization plans describing
+                which stored secrets to make available to this run. Same
+                shape as ``execute_python_code``'s ``credentials`` argument:
 
-    if not is_sandbox_available():
-        return Command(
-            update={
-                "messages": [
-                    ToolMessage(
-                        content="Error: Code sandbox is not available (DAYTONA_API_KEY not set).",
-                        tool_call_id=runtime.tool_call_id,
-                    )
-                ],
-            }
-        )
+                    {"kind": "env_vars", "names": ["TAHMO_USERNAME", "TAHMO_PASSWORD"]}
 
-    thread_id = runtime.config.get("configurable", {}).get("thread_id", "default")
+                    {"kind": "file", "path": "~/.netrc",
+                     "names": ["NASA_USERNAME", "NASA_PASSWORD"],
+                     "content": "machine x login {NASA_USERNAME} password {NASA_PASSWORD}\\n"}
 
-    def _run():
-        sandbox = _get_or_create_sandbox(thread_id)
+                When an MCP tool returns a skill document with a
+                ``requires_credentials`` frontmatter block, copy the relevant
+                entries from that block verbatim into this argument.
 
-        # Write script to sandbox and run via uv for PEP 723 dependency resolution
-        filename = path.lstrip("/")
-        sandbox.fs.upload_file(code.encode("utf-8"), filename)
+                The user must approve the run before any credential is
+                injected. Do not print, log, or echo credential values from
+                your script — the system will redact verbatim occurrences
+                from output as a backstop, and the user can see which secret
+                names you requested in the approval card.
+        """
+        if not path.startswith("/"):
+            path = "/" + path
 
-        # Snapshot files after upload but before execution to detect new output files
-        try:
-            pre_files = {f.name for f in sandbox.fs.list_files(".")}
-        except Exception:
-            pre_files = set()
+        files = runtime.state.get("files", {})
+        file_data = files.get(path)
+        if not file_data:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"Error: File not found: {path}",
+                            tool_call_id=runtime.tool_call_id,
+                        )
+                    ],
+                }
+            )
 
-        response = sandbox.process.exec(f"uv run {filename}")
+        content_lines = file_data.get("content", [])
+        code = "\n".join(content_lines)
 
-        # Discover new files created during execution
-        new_files = {}
-        try:
-            post_files = sandbox.fs.list_files(".")
-            for f in post_files:
-                if f.is_dir or f.name in pre_files:
-                    continue
-                # Download new output files (skip large files > 1MB)
-                if f.size and f.size > 1_000_000:
-                    continue
+        if not code.strip():
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"Error: File is empty: {path}",
+                            tool_call_id=runtime.tool_call_id,
+                        )
+                    ],
+                }
+            )
+
+        from .sandbox import _get_or_create_sandbox, is_sandbox_available
+
+        if not is_sandbox_available():
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content="Error: Code sandbox is not available (DAYTONA_API_KEY not set).",
+                            tool_call_id=runtime.tool_call_id,
+                        )
+                    ],
+                }
+            )
+
+        thread_id = runtime.config.get("configurable", {}).get("thread_id", "default")
+        materializations = credentials or []
+
+        # Resolve credentials before touching the sandbox so a bad request
+        # never has any side effects.
+        resolved = await resolve_credentials_or_error(db, thread_id, materializations, runtime.tool_call_id)
+        if isinstance(resolved, Command):
+            return resolved
+        env_vars, file_uploads, redaction_list = resolved
+
+        def _run():
+            sandbox = _get_or_create_sandbox(thread_id)
+
+            # Apply file materializations (e.g. ~/.netrc) before running.
+            # Always 0600 — these are credential files.
+            for cred_path, content in file_uploads.items():
                 try:
-                    content_bytes = sandbox.fs.download_file(f.name)
-                    ext = "." + f.name.rsplit(".", 1)[-1].lower() if "." in f.name else ""
-                    if ext in _BINARY_EXTENSIONS:
-                        new_files[f"/{f.name}"] = {
-                            "content": base64.b64encode(content_bytes).decode("ascii"),
-                            "encoding": "base64",
-                        }
-                    else:
-                        new_files[f"/{f.name}"] = {
-                            "content": content_bytes.decode("utf-8", errors="replace"),
-                            "encoding": "utf-8",
-                        }
+                    sandbox.fs.upload_file(cred_path, content.encode("utf-8"))
+                except Exception:
+                    logger.warning("Failed to upload credential file %s", cred_path, exc_info=True)
+                try:
+                    sandbox.process.exec(f"chmod 600 {cred_path}")
                 except Exception:
                     pass
-        except Exception:
-            pass
 
-        if response.exit_code != 0:
-            return f"Error (exit code {response.exit_code}):\n{response.result}", new_files
-        return response.result, new_files
+            # Write the script itself to the sandbox.
+            filename = path.lstrip("/")
+            sandbox.fs.upload_file(code.encode("utf-8"), filename)
 
-    result, new_files = await asyncio.to_thread(_run)
+            # Snapshot files after upload but before execution to detect new output files
+            try:
+                pre_files = {f.name for f in sandbox.fs.list_files(".")}
+            except Exception:
+                pre_files = set()
 
-    # Add any output files to state
-    now = datetime.now(UTC).isoformat()
-    files_update = {}
-    for fpath, finfo in new_files.items():
-        encoding = finfo["encoding"]
-        raw = finfo["content"]
-        if encoding == "base64":
-            files_update[fpath] = {
-                "content": [raw],  # Single base64 string as one "line"
-                "source": "output",
-                "encoding": "base64",
-                "modified_at": now,
-            }
-        else:
-            lines = raw.split("\n")
-            files_update[fpath] = {
-                "content": lines,
-                "source": "output",
-                "modified_at": now,
-            }
+            # sandbox.process.exec accepts an env dict that's merged into
+            # the process environment for this single command, which is
+            # exactly the per-execution scoping we want for credentials.
+            if env_vars:
+                response = sandbox.process.exec(f"uv run {filename}", env=dict(env_vars))
+            else:
+                response = sandbox.process.exec(f"uv run {filename}")
 
-    update_dict = {
-        "messages": [
-            ToolMessage(
-                content=f"Execution output for {path}:\n{result}",
-                tool_call_id=runtime.tool_call_id,
-            )
-        ],
-    }
+            # Discover new files created during execution
+            new_files = {}
+            try:
+                post_files = sandbox.fs.list_files(".")
+                for f in post_files:
+                    if f.is_dir or f.name in pre_files:
+                        continue
+                    # Download new output files (skip large files > 1MB)
+                    if f.size and f.size > 1_000_000:
+                        continue
+                    try:
+                        content_bytes = sandbox.fs.download_file(f.name)
+                        ext = "." + f.name.rsplit(".", 1)[-1].lower() if "." in f.name else ""
+                        if ext in _BINARY_EXTENSIONS:
+                            new_files[f"/{f.name}"] = {
+                                "content": base64.b64encode(content_bytes).decode("ascii"),
+                                "encoding": "base64",
+                            }
+                        else:
+                            new_files[f"/{f.name}"] = {
+                                "content": content_bytes.decode("utf-8", errors="replace"),
+                                "encoding": "utf-8",
+                            }
+                    except Exception:
+                        pass
+            except Exception:
+                pass
 
-    if files_update:
-        existing_files = runtime.state.get("files", {})
-        update_dict["files"] = {**existing_files, **files_update}
+            # Best-effort cleanup of credential files so they don't linger
+            # between executions.
+            for cred_path in file_uploads:
+                try:
+                    sandbox.process.exec(f"rm -f {cred_path}")
+                except Exception:
+                    pass
 
-    return Command(update=update_dict)
+            if response.exit_code != 0:
+                return f"Error (exit code {response.exit_code}):\n{response.result}", new_files
+            return response.result, new_files
+
+        result, new_files = await asyncio.to_thread(_run)
+
+        # Backstop: scrub verbatim secret values from anything we return.
+        result = redact_output(result, redaction_list)
+
+        # Add any output files to state, with values redacted.
+        now = datetime.now(UTC).isoformat()
+        files_update = {}
+        for fpath, finfo in new_files.items():
+            encoding = finfo["encoding"]
+            raw = finfo["content"]
+            if encoding == "base64":
+                files_update[fpath] = {
+                    "content": [raw],  # Single base64 string as one "line"
+                    "source": "output",
+                    "encoding": "base64",
+                    "modified_at": now,
+                }
+            else:
+                redacted = redact_output(raw, redaction_list)
+                lines = redacted.split("\n")
+                files_update[fpath] = {
+                    "content": lines,
+                    "source": "output",
+                    "modified_at": now,
+                }
+
+        update_dict = {
+            "messages": [
+                ToolMessage(
+                    content=f"Execution output for {path}:\n{result}",
+                    tool_call_id=runtime.tool_call_id,
+                )
+            ],
+        }
+
+        if files_update:
+            existing_files = runtime.state.get("files", {})
+            update_dict["files"] = {**existing_files, **files_update}
+
+        return Command(update=update_dict)
+
+    return run_file

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -1,15 +1,39 @@
-"""Daytona sandbox tool for code execution."""
+"""Daytona sandbox tool for code execution.
+
+The ``execute_python_code`` tool is built as a factory
+(``make_execute_python_code``) so it can close over the application
+database. The tool needs the database to look up the conversation's
+owner and resolve credential references at tool-call time.
+
+Credential model: the LLM passes a list of materialization plans on each
+call (``credentials=[{kind: env_vars, names: [...]}, {kind: file, ...}]``).
+Each plan tells the system which stored secret names to inject and how.
+The system validates that every referenced name exists in the user's
+store, then the existing HITL approval middleware interrupts so the
+user can review the code AND the credential names before anything runs.
+On approval, decrypted secret values are injected into the sandbox via
+``CodeRunParams.env`` (env vars) or ``fs.upload_file`` (files), the code
+runs, and verbatim secret values are scrubbed from output as a backstop.
+"""
 
 import asyncio
 import base64
 import logging
 import os
 from datetime import UTC, datetime
+from typing import Any
 
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langgraph.prebuilt import ToolRuntime
 from langgraph.types import Command
+
+from ...credentials import (
+    decrypt_value,
+    extract_placeholders,
+    redact_output,
+    substitute_placeholders,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -141,99 +165,453 @@ async def cleanup_idle_sandboxes():
     await asyncio.to_thread(_cleanup_idle_sandboxes)
 
 
-@tool
-async def execute_python_code(
-    code: str,
-    *,
-    runtime: ToolRuntime,
-) -> Command:
-    """Execute Python code in a sandboxed environment and return the output.
+def _collect_referenced_names(materializations: list[dict]) -> list[str]:
+    """Walk a materialization list and collect every secret name it references.
 
-    Use this tool to run data analysis, computations, or any Python code.
-    The sandbox persists across calls within the same conversation, so you
-    can build on previous code executions.
+    Both ``env_vars`` and ``file`` kinds carry an explicit ``names`` list, so
+    this is just the deduplicated union of those lists in the order they
+    first appear. Used both for validation (before HITL) and for redaction
+    list construction (after decryption).
+    """
+    seen: dict[str, None] = {}
+    for m in materializations or []:
+        if not isinstance(m, dict):
+            continue
+        for n in m.get("names") or []:
+            if isinstance(n, str):
+                seen.setdefault(n, None)
+    return list(seen.keys())
+
+
+def _validate_materializations(materializations: Any) -> str | None:
+    """Validate the structural shape of the credentials argument.
+
+    Returns an error string if invalid, or None if OK. Does not check
+    name existence in the user's credential store — that's a separate step
+    that needs the db.
+
+    Accepted shapes:
+
+        {"kind": "env_vars", "names": ["NAME1", "NAME2"]}
+
+        {"kind": "file", "path": "~/.netrc", "names": ["NAME1", "NAME2"],
+         "content": "...{NAME1}...{NAME2}..."}
+
+    For the file kind, every ``{NAME}`` placeholder in ``content`` MUST also
+    appear in the explicit ``names`` list — this catches the LLM mismatching
+    its placeholders against its declared accessed names.
+    """
+    if not isinstance(materializations, list):
+        return "credentials must be a list of materialization plans"
+    for i, m in enumerate(materializations):
+        if not isinstance(m, dict):
+            return f"credentials[{i}] must be an object"
+        kind = m.get("kind")
+        names = m.get("names")
+        if not isinstance(names, list) or not names or not all(isinstance(n, str) and n for n in names):
+            return f"credentials[{i}].names must be a non-empty list of secret names"
+        if kind == "env_vars":
+            pass  # names already validated
+        elif kind == "file":
+            path = m.get("path")
+            content = m.get("content")
+            if not isinstance(path, str) or not path:
+                return f"credentials[{i}].path must be a non-empty string"
+            if not isinstance(content, str):
+                return f"credentials[{i}].content must be a string"
+            placeholders = set(extract_placeholders(content))
+            declared = set(names)
+            missing = placeholders - declared
+            if missing:
+                return (
+                    f"credentials[{i}].content references {sorted(missing)} but "
+                    f"those names are not in credentials[{i}].names"
+                )
+        else:
+            return f"credentials[{i}].kind must be 'env_vars' or 'file'"
+    return None
+
+
+async def _resolve_secrets(db, user_id: str, names: list[str]) -> tuple[dict[str, str] | None, str | None]:
+    """Decrypt every named secret for a user.
+
+    Returns ``(values, None)`` on success or ``(None, error_string)`` if any
+    name is missing from the user's store. Caller must have already
+    validated the materialization shape.
+    """
+    values: dict[str, str] = {}
+    for name in names:
+        ct = await db.get_credential_ciphertext_by_name(user_id, name)
+        if ct is None:
+            return None, f"credential {name!r} is not configured — add it in settings"
+        try:
+            values[name] = decrypt_value(ct)
+        except Exception as e:  # pragma: no cover - decrypt should not fail in practice
+            return None, f"failed to decrypt credential {name!r}: {e}"
+    return values, None
+
+
+def _build_runtime_injection(
+    materializations: list[dict],
+    secret_values: dict[str, str],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Turn validated materializations + decrypted values into env vars and files.
+
+    Returns ``(env_vars, files)`` where ``env_vars`` is a flat dict for
+    ``CodeRunParams.env`` and ``files`` is a dict of ``path -> content`` ready
+    to upload. When two ``file`` materializations target the same path,
+    their content is concatenated in the order the LLM listed them.
+    """
+    env: dict[str, str] = {}
+    files: dict[str, str] = {}
+    for m in materializations:
+        if m["kind"] == "env_vars":
+            for name in m["names"]:
+                env[name] = secret_values[name]
+        elif m["kind"] == "file":
+            path = m["path"]
+            rendered = substitute_placeholders(m["content"], secret_values)
+            if path in files:
+                files[path] = files[path] + rendered
+            else:
+                files[path] = rendered
+    return env, files
+
+
+async def resolve_credentials_or_error(
+    db,
+    thread_id: str,
+    materializations: list[dict],
+    tool_call_id: str,
+) -> tuple[dict[str, str], dict[str, str], list[str]] | Command:
+    """Validate, resolve, and decrypt the credentials for one tool call.
+
+    Shared by ``execute_python_code`` and ``run_file`` so both tools have
+    the exact same credential semantics.
+
+    Returns ``(env_vars, file_uploads, redaction_list)`` on success, or a
+    ``Command`` carrying a tool-error message on any failure (bad shape,
+    missing credential, decryption failure, etc). The caller should check
+    ``isinstance(result, Command)`` and short-circuit on that branch.
+
+    The decrypted secret values are kept only inside this function's local
+    scope until they are baked into ``env_vars`` and rendered file content;
+    the caller never sees the raw payload dict.
+    """
+    if not materializations:
+        return {}, {}, []
+
+    shape_error = _validate_materializations(materializations)
+    if shape_error:
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=f"Credential error: {shape_error}",
+                        tool_call_id=tool_call_id,
+                        status="error",
+                    )
+                ]
+            }
+        )
+
+    referenced_names = _collect_referenced_names(materializations)
+    if not referenced_names:
+        return {}, {}, []
+
+    if db is None:
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content="Credential error: credentials feature is not configured",
+                        tool_call_id=tool_call_id,
+                        status="error",
+                    )
+                ]
+            }
+        )
+
+    convo = await db.get_conversation_by_id(thread_id)
+    if not convo:
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content="Credential error: cannot resolve conversation owner",
+                        tool_call_id=tool_call_id,
+                        status="error",
+                    )
+                ]
+            }
+        )
+
+    secret_values, err = await _resolve_secrets(db, convo["user_id"], referenced_names)
+    if err:
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=f"Credential error: {err}",
+                        tool_call_id=tool_call_id,
+                        status="error",
+                    )
+                ]
+            }
+        )
+
+    env_vars, file_uploads = _build_runtime_injection(materializations, secret_values)
+    redaction_list = list(secret_values.values())
+    secret_values.clear()
+    return env_vars, file_uploads, redaction_list
+
+
+def make_execute_python_code(db=None):
+    """Build the ``execute_python_code`` tool with credential support.
 
     Args:
-        code: Python code to execute.
+        db: Application database. Required for credential resolution.
+            When None, the tool still runs but rejects any non-empty
+            ``credentials`` argument.
+
+    Returns the configured ``execute_python_code`` tool.
     """
-    thread_id = runtime.config.get("configurable", {}).get("thread_id", "default")
 
-    def _run():
-        sandbox = _get_or_create_sandbox(thread_id)
+    @tool
+    async def execute_python_code(
+        code: str,
+        credentials: list[dict] | None = None,
+        *,
+        runtime: ToolRuntime,
+    ) -> Command:
+        """Execute Python code in a sandboxed environment and return the output.
 
-        # Snapshot files before execution to detect new output files
-        try:
-            pre_files = {f.name for f in sandbox.fs.list_files(".")}
-        except Exception:
-            pre_files = set()
+        Use this tool to run data analysis, computations, or any Python code.
+        The sandbox persists across calls within the same conversation, so
+        you can build on previous code executions.
 
-        response = sandbox.process.code_run(code)
+        Args:
+            code: Python code to execute.
+            credentials: Optional list of materialization plans describing
+                which stored secrets to make available to this run. When an
+                MCP tool returns a skill document with a ``requires_credentials``
+                frontmatter block, copy the relevant entries from that block
+                verbatim into this argument. The entries have the same shape
+                in the frontmatter and in this tool argument so no
+                interpretation is needed.
 
-        # Discover new files created during execution
-        new_files = {}
-        try:
-            post_files = sandbox.fs.list_files(".")
-            for f in post_files:
-                if f.is_dir or f.name in pre_files:
-                    continue
-                # Skip large files > 1MB
-                if f.size and f.size > 1_000_000:
-                    continue
+                Each entry has a ``kind`` of either ``env_vars`` or ``file``,
+                and an explicit ``names`` list enumerating the stored secrets
+                it touches.
+
+                ``env_vars`` entries set environment variables. The env var
+                name is the same as the stored secret name:
+
+                    {"kind": "env_vars", "names": ["TAHMO_USERNAME", "TAHMO_PASSWORD"]}
+
+                ``file`` entries write a file with templated content. Use
+                ``{NAME}`` placeholders in ``content`` to inject stored
+                secret values; the same names must also appear in the
+                ``names`` list:
+
+                    {"kind": "file", "path": "~/.netrc",
+                     "names": ["NASA_USERNAME", "NASA_PASSWORD"],
+                     "content": "machine x login {NASA_USERNAME} password {NASA_PASSWORD}\\n"}
+
+                The user must approve the run before any credential is
+                injected. Do not print, log, or echo credential values
+                from your script — the system will redact verbatim
+                occurrences from output as a backstop, and the user can see
+                which secret names you requested in the approval card.
+        """
+        thread_id = runtime.config.get("configurable", {}).get("thread_id", "default")
+        materializations = credentials or []
+
+        # 1. Structural validation. Bad shapes get rejected with a
+        #    tool-error message that the LLM can read and correct from.
+        shape_error = _validate_materializations(materializations)
+        if shape_error:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=f"Credential error: {shape_error}",
+                            tool_call_id=runtime.tool_call_id,
+                            status="error",
+                        )
+                    ]
+                }
+            )
+
+        # 2. Resolve referenced names against the user's store. If any name
+        #    is missing, reject before running anything.
+        referenced_names = _collect_referenced_names(materializations)
+        secret_values: dict[str, str] = {}
+        if referenced_names:
+            if db is None:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content="Credential error: credentials feature is not configured",
+                                tool_call_id=runtime.tool_call_id,
+                                status="error",
+                            )
+                        ]
+                    }
+                )
+            convo = await db.get_conversation_by_id(thread_id)
+            if not convo:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content="Credential error: cannot resolve conversation owner",
+                                tool_call_id=runtime.tool_call_id,
+                                status="error",
+                            )
+                        ]
+                    }
+                )
+            user_id = convo["user_id"]
+            secret_values, err = await _resolve_secrets(db, user_id, referenced_names)
+            if err:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content=f"Credential error: {err}",
+                                tool_call_id=runtime.tool_call_id,
+                                status="error",
+                            )
+                        ]
+                    }
+                )
+
+        # 3. Build the per-execution env vars and file uploads from the
+        #    decrypted values. Drop the values dict immediately after.
+        env_vars, file_uploads = _build_runtime_injection(materializations, secret_values)
+        redaction_list = list(secret_values.values())
+        secret_values.clear()
+
+        def _run():
+            sandbox = _get_or_create_sandbox(thread_id)
+
+            # Apply file materializations before running. These persist for
+            # the lifetime of the sandbox; future runs that don't request
+            # them will still see them in the filesystem until the sandbox
+            # is recycled. Best-effort cleanup happens after the run.
+            for path, content in file_uploads.items():
                 try:
-                    content_bytes = sandbox.fs.download_file(f.name)
-                    ext = "." + f.name.rsplit(".", 1)[-1].lower() if "." in f.name else ""
-                    if ext in _BINARY_EXTENSIONS:
-                        new_files[f"/{f.name}"] = {
-                            "content": base64.b64encode(content_bytes).decode("ascii"),
-                            "encoding": "base64",
-                        }
-                    else:
-                        new_files[f"/{f.name}"] = {
-                            "content": content_bytes.decode("utf-8", errors="replace"),
-                            "encoding": "utf-8",
-                        }
+                    sandbox.fs.upload_file(path, content.encode("utf-8"))
+                except Exception:
+                    logger.warning("Failed to upload credential file %s", path, exc_info=True)
+                # netrc and similar credential files conventionally need
+                # restrictive permissions; default everything to 0600.
+                try:
+                    sandbox.process.exec(f"chmod 600 {path}")
                 except Exception:
                     pass
-        except Exception:
-            pass
 
-        if response.exit_code != 0:
-            return f"Error (exit code {response.exit_code}):\n{response.result}", new_files
-        return response.result, new_files
+            # Snapshot files before execution to detect new output files
+            try:
+                pre_files = {f.name for f in sandbox.fs.list_files(".")}
+            except Exception:
+                pre_files = set()
 
-    result, new_files = await asyncio.to_thread(_run)
+            run_params = None
+            if env_vars:
+                try:
+                    from daytona_sdk import CodeRunParams
 
-    # Build files state update from captured output files
-    now = datetime.now(UTC).isoformat()
-    files_update = {}
-    for fpath, finfo in new_files.items():
-        encoding = finfo["encoding"]
-        raw = finfo["content"]
-        if encoding == "base64":
-            files_update[fpath] = {
-                "content": [raw],
-                "source": "output",
-                "encoding": "base64",
-                "modified_at": now,
-            }
-        else:
-            lines = raw.split("\n")
-            files_update[fpath] = {
-                "content": lines,
-                "source": "output",
-                "modified_at": now,
-            }
+                    run_params = CodeRunParams(env=dict(env_vars))
+                except Exception:
+                    logger.warning("Failed to build CodeRunParams; env vars will not be set", exc_info=True)
 
-    update_dict: dict = {
-        "messages": [
-            ToolMessage(
-                content=result,
-                tool_call_id=runtime.tool_call_id,
-            )
-        ],
-    }
+            if run_params is not None:
+                response = sandbox.process.code_run(code, params=run_params)
+            else:
+                response = sandbox.process.code_run(code)
 
-    if files_update:
-        update_dict["files"] = files_update
+            # Discover new files created during execution
+            new_files = {}
+            try:
+                post_files = sandbox.fs.list_files(".")
+                for f in post_files:
+                    if f.is_dir or f.name in pre_files:
+                        continue
+                    # Skip large files > 1MB
+                    if f.size and f.size > 1_000_000:
+                        continue
+                    try:
+                        content_bytes = sandbox.fs.download_file(f.name)
+                        ext = "." + f.name.rsplit(".", 1)[-1].lower() if "." in f.name else ""
+                        if ext in _BINARY_EXTENSIONS:
+                            new_files[f"/{f.name}"] = {
+                                "content": base64.b64encode(content_bytes).decode("ascii"),
+                                "encoding": "base64",
+                            }
+                        else:
+                            new_files[f"/{f.name}"] = {
+                                "content": content_bytes.decode("utf-8", errors="replace"),
+                                "encoding": "utf-8",
+                            }
+                    except Exception:
+                        pass
+            except Exception:
+                pass
 
-    return Command(update=update_dict)
+            # Best-effort cleanup of credential files so they don't linger
+            # between executions.
+            for path in file_uploads:
+                try:
+                    sandbox.process.exec(f"rm -f {path}")
+                except Exception:
+                    pass
+
+            if response.exit_code != 0:
+                return f"Error (exit code {response.exit_code}):\n{response.result}", new_files
+            return response.result, new_files
+
+        result, new_files = await asyncio.to_thread(_run)
+
+        # Backstop: scrub verbatim secret values from anything we return.
+        result = redact_output(result, redaction_list)
+
+        # Build files state update from captured output files
+        now = datetime.now(UTC).isoformat()
+        files_update = {}
+        for fpath, finfo in new_files.items():
+            encoding = finfo["encoding"]
+            raw = finfo["content"]
+            if encoding == "base64":
+                files_update[fpath] = {
+                    "content": [raw],
+                    "source": "output",
+                    "encoding": "base64",
+                    "modified_at": now,
+                }
+            else:
+                redacted = redact_output(raw, redaction_list)
+                lines = redacted.split("\n")
+                files_update[fpath] = {
+                    "content": lines,
+                    "source": "output",
+                    "modified_at": now,
+                }
+
+        update_dict: dict = {
+            "messages": [
+                ToolMessage(
+                    content=result,
+                    tool_call_id=runtime.tool_call_id,
+                )
+            ],
+        }
+
+        if files_update:
+            update_dict["files"] = files_update
+
+        return Command(update=update_dict)
+
+    return execute_python_code

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -38,6 +38,30 @@ from ...credentials import (
 logger = logging.getLogger(__name__)
 
 # File extensions that should be stored as base64-encoded binary
+# Daytona's filesystem API (``sandbox.fs.upload_file``) treats paths as
+# relative to the sandbox's home directory. Passing ``~/.netrc`` literally
+# creates a directory named ``~`` instead of expanding the tilde, and
+# passing absolute paths like ``/root/.netrc`` ends up under
+# ``<home>/root/.netrc``. Normalize all credential file paths through this
+# helper so they land where the script expects to find them.
+#
+# Shell commands like ``chmod`` and ``rm`` go through ``sandbox.process.exec``
+# which runs in a shell that expands ``~`` correctly, so they keep using the
+# original logical path.
+_SANDBOX_HOME = "/root"
+
+
+def _normalize_sandbox_upload_path(path: str) -> str:
+    """Convert a logical sandbox path to the form Daytona's fs.upload_file expects."""
+    if path.startswith("~/"):
+        return path[2:]
+    if path.startswith(_SANDBOX_HOME + "/"):
+        return path[len(_SANDBOX_HOME) + 1 :]
+    if path.startswith("/"):
+        return path[1:]
+    return path
+
+
 _BINARY_EXTENSIONS = {
     ".png",
     ".jpg",
@@ -501,13 +525,21 @@ def make_execute_python_code(db=None):
             # the lifetime of the sandbox; future runs that don't request
             # them will still see them in the filesystem until the sandbox
             # is recycled. Best-effort cleanup happens after the run.
+            #
+            # Daytona's upload_file signature is (content_bytes, remote_path),
+            # NOT (remote_path, content_bytes). And remote_path is resolved
+            # against the sandbox's working directory and does NOT expand
+            # ``~``, so the path is normalized first.
             for path, content in file_uploads.items():
+                upload_path = _normalize_sandbox_upload_path(path)
                 try:
-                    sandbox.fs.upload_file(path, content.encode("utf-8"))
+                    sandbox.fs.upload_file(content.encode("utf-8"), upload_path)
                 except Exception:
                     logger.warning("Failed to upload credential file %s", path, exc_info=True)
                 # netrc and similar credential files conventionally need
-                # restrictive permissions; default everything to 0600.
+                # restrictive permissions; default everything to 0600. Use
+                # the original logical path here — chmod runs in a shell
+                # that expands ``~`` correctly.
                 try:
                     sandbox.process.exec(f"chmod 600 {path}")
                 except Exception:

--- a/src/rhiza_agents/app.py
+++ b/src/rhiza_agents/app.py
@@ -173,7 +173,17 @@ def create_app() -> FastAPI:
     app.mount("/static", StaticFiles(directory=base_dir / "static"), name="static")
 
     # Register route modules
-    from .routes import agents, chat, conversations, mcp_servers, pages, settings, skills, vectorstores
+    from .routes import (
+        agents,
+        chat,
+        conversations,
+        credentials,
+        mcp_servers,
+        pages,
+        settings,
+        skills,
+        vectorstores,
+    )
 
     app.include_router(pages.router)
     app.include_router(chat.router)
@@ -183,6 +193,7 @@ def create_app() -> FastAPI:
     app.include_router(vectorstores.router)
     app.include_router(conversations.router)
     app.include_router(settings.router)
+    app.include_router(credentials.router)
 
     return app
 

--- a/src/rhiza_agents/config.py
+++ b/src/rhiza_agents/config.py
@@ -44,6 +44,9 @@ class Config:
     langfuse_secret_key: str
     langfuse_base_url: str
 
+    # Credential encryption (feature is disabled if unset)
+    credential_encryption_key: str
+
     @classmethod
     def from_env(cls) -> "Config":
         """Load configuration from environment variables."""
@@ -69,4 +72,5 @@ class Config:
             langfuse_public_key=os.environ.get("LANGFUSE_PUBLIC_KEY", ""),
             langfuse_secret_key=os.environ.get("LANGFUSE_SECRET_KEY", ""),
             langfuse_base_url=os.environ.get("LANGFUSE_BASE_URL", ""),
+            credential_encryption_key=os.environ.get("CREDENTIAL_ENCRYPTION_KEY", ""),
         )

--- a/src/rhiza_agents/credentials.py
+++ b/src/rhiza_agents/credentials.py
@@ -1,0 +1,134 @@
+"""User-scoped credentials: encryption at rest + output redaction.
+
+The credentials feature is opt-in: the encryption key comes from the
+``CREDENTIAL_ENCRYPTION_KEY`` env var (a 32-byte urlsafe-base64 Fernet key).
+When the var is unset, ``credentials_enabled()`` returns False and all
+encrypt/decrypt calls raise — the API layer must short-circuit to a 503
+in that case so the feature fails closed.
+
+Stored credentials are flat name/value pairs. The LLM never sees values;
+it only sees the available *names* via the system prompt and approval
+card. Values are injected into sandbox executions at run time per the
+materialization plan the LLM provides in its tool call.
+"""
+
+import base64
+import logging
+import os
+import re
+
+from cryptography.fernet import Fernet
+
+logger = logging.getLogger(__name__)
+
+
+_fernet: Fernet | None = None
+_fernet_initialized = False
+
+
+def _get_fernet() -> Fernet | None:
+    """Lazily build the Fernet instance from CREDENTIAL_ENCRYPTION_KEY.
+
+    Returns None when the env var is unset — callers must treat that as
+    "credentials feature disabled" and refuse to store or read secrets.
+    """
+    global _fernet, _fernet_initialized
+    if _fernet_initialized:
+        return _fernet
+    _fernet_initialized = True
+    raw = os.environ.get("CREDENTIAL_ENCRYPTION_KEY", "").strip()
+    if not raw:
+        logger.warning("CREDENTIAL_ENCRYPTION_KEY not set — credentials feature disabled")
+        return None
+    try:
+        # Fernet keys are urlsafe-base64-encoded 32-byte strings.
+        _fernet = Fernet(raw.encode())
+    except Exception:
+        try:
+            decoded = base64.urlsafe_b64decode(raw)
+            if len(decoded) != 32:
+                raise ValueError(f"key must decode to 32 bytes, got {len(decoded)}")
+            _fernet = Fernet(base64.urlsafe_b64encode(decoded))
+        except Exception as e:
+            logger.error("CREDENTIAL_ENCRYPTION_KEY is invalid: %s", e)
+            return None
+    return _fernet
+
+
+def credentials_enabled() -> bool:
+    """Return True if the encryption key is configured and the feature is live."""
+    return _get_fernet() is not None
+
+
+def encrypt_value(value: str) -> bytes:
+    """Encrypt a single secret value.
+
+    Raises RuntimeError if the encryption key is not configured.
+    """
+    f = _get_fernet()
+    if f is None:
+        raise RuntimeError("credentials feature is disabled (CREDENTIAL_ENCRYPTION_KEY not set)")
+    return f.encrypt(value.encode("utf-8"))
+
+
+def decrypt_value(ciphertext: bytes) -> str:
+    """Decrypt a previously-encrypted secret value back to a string.
+
+    Raises RuntimeError if the encryption key is not configured, or
+    cryptography's InvalidToken if the ciphertext was produced with a
+    different key.
+    """
+    f = _get_fernet()
+    if f is None:
+        raise RuntimeError("credentials feature is disabled (CREDENTIAL_ENCRYPTION_KEY not set)")
+    if isinstance(ciphertext, memoryview):
+        ciphertext = bytes(ciphertext)
+    return f.decrypt(ciphertext).decode("utf-8")
+
+
+# A {NAME} placeholder in a file content template. Names follow common
+# environment-variable conventions (letters, digits, underscore; not
+# starting with a digit) so we don't accidentally substitute braces in
+# arbitrary file content.
+PLACEHOLDER_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def extract_placeholders(template: str) -> list[str]:
+    """Return the ordered list of ``{NAME}`` placeholder names in a template."""
+    return PLACEHOLDER_RE.findall(template or "")
+
+
+def substitute_placeholders(template: str, values: dict[str, str]) -> str:
+    """Replace ``{NAME}`` placeholders in ``template`` with values from ``values``.
+
+    Unknown placeholders are left untouched and a warning is logged. Caller
+    is expected to have validated that every placeholder has a corresponding
+    secret before calling this.
+    """
+
+    def _sub(match: re.Match) -> str:
+        name = match.group(1)
+        if name in values:
+            return values[name]
+        logger.warning("Template references unknown placeholder %r", name)
+        return match.group(0)
+
+    return PLACEHOLDER_RE.sub(_sub, template)
+
+
+def redact_output(text: str, secret_values: list[str]) -> str:
+    """Replace verbatim occurrences of any secret value with ``[REDACTED]``.
+
+    Backstop only: the structural defense is that the LLM never sees the
+    values to begin with. This catches accidental leaks via stdout, stderr,
+    or captured output files. Sophisticated transformations (base64,
+    slicing, etc.) defeat it; do not rely on this for adversarial scripts.
+    """
+    if not text or not secret_values:
+        return text
+    # Replace longer values first so a value that contains another value
+    # gets redacted as a single unit.
+    for value in sorted({v for v in secret_values if v}, key=lambda v: -len(v)):
+        if value in text:
+            text = text.replace(value, "[REDACTED]")
+    return text

--- a/src/rhiza_agents/credentials.py
+++ b/src/rhiza_agents/credentials.py
@@ -1,10 +1,17 @@
 """User-scoped credentials: encryption at rest + output redaction.
 
-The credentials feature is opt-in: the encryption key comes from the
-``CREDENTIAL_ENCRYPTION_KEY`` env var (a 32-byte urlsafe-base64 Fernet key).
-When the var is unset, ``credentials_enabled()`` returns False and all
-encrypt/decrypt calls raise — the API layer must short-circuit to a 503
-in that case so the feature fails closed.
+The credentials feature is opt-in. ``CREDENTIAL_ENCRYPTION_KEY`` is a
+high-entropy random seed string. At startup it is hashed with SHA-256
+and the digest is urlsafe-base64-encoded to produce the actual Fernet
+key, so the operator can supply any random string without needing a
+Fernet-specific generator.
+
+When the env var is unset, ``credentials_enabled()`` returns False and
+all encrypt/decrypt calls raise — the API layer must short-circuit to a
+503 in that case so the feature fails closed.
+
+The seed must be stable across deployments. If it changes, every
+previously-stored encrypted credential becomes unreadable.
 
 Stored credentials are flat name/value pairs. The LLM never sees values;
 it only sees the available *names* via the system prompt and approval
@@ -13,6 +20,7 @@ materialization plan the LLM provides in its tool call.
 """
 
 import base64
+import hashlib
 import logging
 import os
 import re
@@ -26,6 +34,17 @@ _fernet: Fernet | None = None
 _fernet_initialized = False
 
 
+def _derive_fernet_key(seed: str) -> bytes:
+    """Derive a Fernet key (44-char urlsafe-base64 of 32 bytes) from a seed.
+
+    SHA-256 always produces 32 bytes, and ``urlsafe_b64encode`` of 32 bytes
+    is always the 44-character padded urlsafe-base64 string Fernet expects.
+    Any non-empty seed string is therefore valid input.
+    """
+    digest = hashlib.sha256(seed.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest)
+
+
 def _get_fernet() -> Fernet | None:
     """Lazily build the Fernet instance from CREDENTIAL_ENCRYPTION_KEY.
 
@@ -36,22 +55,11 @@ def _get_fernet() -> Fernet | None:
     if _fernet_initialized:
         return _fernet
     _fernet_initialized = True
-    raw = os.environ.get("CREDENTIAL_ENCRYPTION_KEY", "").strip()
-    if not raw:
+    seed = os.environ.get("CREDENTIAL_ENCRYPTION_KEY", "").strip()
+    if not seed:
         logger.warning("CREDENTIAL_ENCRYPTION_KEY not set — credentials feature disabled")
         return None
-    try:
-        # Fernet keys are urlsafe-base64-encoded 32-byte strings.
-        _fernet = Fernet(raw.encode())
-    except Exception:
-        try:
-            decoded = base64.urlsafe_b64decode(raw)
-            if len(decoded) != 32:
-                raise ValueError(f"key must decode to 32 bytes, got {len(decoded)}")
-            _fernet = Fernet(base64.urlsafe_b64encode(decoded))
-        except Exception as e:
-            logger.error("CREDENTIAL_ENCRYPTION_KEY is invalid: %s", e)
-            return None
+    _fernet = Fernet(_derive_fernet_key(seed))
     return _fernet
 
 

--- a/src/rhiza_agents/db/sqlite.py
+++ b/src/rhiza_agents/db/sqlite.py
@@ -104,6 +104,29 @@ class Database:
         """)
         await self.database.execute("CREATE INDEX IF NOT EXISTS idx_skills_user_id ON skills(user_id)")
 
+        # Per-user encrypted credentials. Each row is one named secret value.
+        # The value column is the only place secret material lives — name is
+        # plain so the API/UI can list and reference it. The encryption key
+        # comes from CREDENTIAL_ENCRYPTION_KEY; without it the credentials
+        # routes refuse to operate (fail-closed).
+        #
+        # (user_id, name) is unique so a name can be referenced unambiguously
+        # in tool calls.
+        await self.database.execute("""
+            CREATE TABLE IF NOT EXISTS user_credentials (
+                id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                value_ciphertext BLOB NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (user_id, name)
+            )
+        """)
+        await self.database.execute(
+            "CREATE INDEX IF NOT EXISTS idx_user_credentials_user_id ON user_credentials(user_id)"
+        )
+
     async def create_conversation(self, conversation_id: str, user_id: str, title: str | None = None) -> dict:
         """Create a new conversation."""
         await self.database.execute(
@@ -475,3 +498,104 @@ class Database:
                 "updated_at": datetime.now(UTC),
             },
         )
+
+    # --- Credentials ---
+
+    async def list_credentials(self, user_id: str) -> list[dict]:
+        """List a user's stored credentials. NEVER includes value_ciphertext."""
+        rows = await self.database.fetch_all(
+            """SELECT id, user_id, name, created_at, updated_at
+               FROM user_credentials WHERE user_id = :user_id ORDER BY name""",
+            {"user_id": user_id},
+        )
+        return [dict(row._mapping) for row in rows]
+
+    async def list_credential_names(self, user_id: str) -> list[str]:
+        """Return just the secret names for a user, sorted. Used by the
+        sandbox tool's resolver and by the system prompt augmentation.
+        """
+        rows = await self.database.fetch_all(
+            "SELECT name FROM user_credentials WHERE user_id = :user_id ORDER BY name",
+            {"user_id": user_id},
+        )
+        return [row._mapping["name"] for row in rows]
+
+    async def get_credential_meta(self, credential_id: str, user_id: str) -> dict | None:
+        """Fetch credential metadata only (no ciphertext). Safe for API responses."""
+        row = await self.database.fetch_one(
+            """SELECT id, user_id, name, created_at, updated_at
+               FROM user_credentials WHERE id = :id AND user_id = :user_id""",
+            {"id": credential_id, "user_id": user_id},
+        )
+        return dict(row._mapping) if row else None
+
+    async def get_credential_ciphertext_by_name(self, user_id: str, name: str) -> bytes | None:
+        """Fetch a single credential's encrypted value by name.
+
+        Used by the sandbox tool when resolving references at execution time.
+        Treat the returned bytes as sensitive — do not log, do not return
+        from API routes, do not pass to the LLM.
+        """
+        row = await self.database.fetch_one(
+            "SELECT value_ciphertext FROM user_credentials WHERE user_id = :user_id AND name = :name",
+            {"user_id": user_id, "name": name},
+        )
+        if not row:
+            return None
+        ct = row._mapping["value_ciphertext"]
+        if isinstance(ct, memoryview):
+            ct = bytes(ct)
+        return ct
+
+    async def create_credential(
+        self,
+        credential_id: str,
+        user_id: str,
+        name: str,
+        value_ciphertext: bytes,
+    ) -> dict:
+        """Create an encrypted credential record."""
+        await self.database.execute(
+            """INSERT INTO user_credentials (id, user_id, name, value_ciphertext)
+               VALUES (:id, :user_id, :name, :value_ciphertext)""",
+            {
+                "id": credential_id,
+                "user_id": user_id,
+                "name": name,
+                "value_ciphertext": value_ciphertext,
+            },
+        )
+        return {"id": credential_id, "user_id": user_id, "name": name}
+
+    async def update_credential(
+        self,
+        credential_id: str,
+        user_id: str,
+        name: str | None = None,
+        value_ciphertext: bytes | None = None,
+    ) -> bool:
+        """Update a credential. Only the owning user may update."""
+        sets: list[str] = []
+        params: dict = {"id": credential_id, "user_id": user_id, "updated_at": datetime.now(UTC)}
+        if name is not None:
+            sets.append("name = :name")
+            params["name"] = name
+        if value_ciphertext is not None:
+            sets.append("value_ciphertext = :value_ciphertext")
+            params["value_ciphertext"] = value_ciphertext
+        if not sets:
+            return False
+        sets.append("updated_at = :updated_at")
+        result = await self.database.execute(
+            f"UPDATE user_credentials SET {', '.join(sets)} WHERE id = :id AND user_id = :user_id",
+            params,
+        )
+        return result > 0 if result else True
+
+    async def delete_credential(self, credential_id: str, user_id: str) -> bool:
+        """Delete a credential."""
+        result = await self.database.execute(
+            "DELETE FROM user_credentials WHERE id = :id AND user_id = :user_id",
+            {"id": credential_id, "user_id": user_id},
+        )
+        return result > 0 if result else True

--- a/src/rhiza_agents/routes/credentials.py
+++ b/src/rhiza_agents/routes/credentials.py
@@ -1,0 +1,152 @@
+"""Credential CRUD API.
+
+The contract: API responses NEVER include the encrypted ciphertext or the
+plaintext value. Only metadata (id, name, timestamps) is exposed. Editing
+a credential means submitting a fresh value — there is no "view" or
+"reveal" affordance, and the form should always treat the stored value
+as opaque.
+
+When ``CREDENTIAL_ENCRYPTION_KEY`` is unset, every route returns 503 so
+the feature fails closed.
+"""
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from ..agents.graph import invalidate_graph_cache
+from ..credentials import credentials_enabled, encrypt_value
+from ..deps import get_db, get_user_id, require_auth
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["credentials"])
+
+
+def _credential_view(row: dict) -> dict:
+    """Project a credential row into the safe public response shape."""
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "created_at": row.get("created_at"),
+        "updated_at": row.get("updated_at"),
+    }
+
+
+def _require_enabled() -> None:
+    if not credentials_enabled():
+        raise HTTPException(
+            status_code=503,
+            detail="Credentials feature is disabled (CREDENTIAL_ENCRYPTION_KEY not set)",
+        )
+
+
+@router.get("/api/credentials")
+async def list_credentials(request: Request, user: dict = Depends(require_auth)):
+    """List all credentials owned by the user. No secret material is returned."""
+    _require_enabled()
+    db = get_db(request)
+    user_id = get_user_id(request)
+    rows = await db.list_credentials(user_id)
+    return [_credential_view(r) for r in rows]
+
+
+class CredentialCreate(BaseModel):
+    name: str
+    value: str
+
+
+@router.post("/api/credentials")
+async def create_credential(request: Request, body: CredentialCreate, user: dict = Depends(require_auth)):
+    _require_enabled()
+    db = get_db(request)
+    user_id = get_user_id(request)
+    name = body.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="name is required")
+    if not body.value:
+        raise HTTPException(status_code=400, detail="value must not be empty")
+
+    # Reject duplicate names up front for a clean error message; the DB
+    # uniqueness constraint backs this up.
+    existing = await db.list_credential_names(user_id)
+    if name in existing:
+        raise HTTPException(status_code=409, detail=f"a credential named {name!r} already exists")
+
+    ciphertext = encrypt_value(body.value)
+    credential_id = f"cred-{uuid.uuid4().hex[:12]}"
+    await db.create_credential(
+        credential_id=credential_id,
+        user_id=user_id,
+        name=name,
+        value_ciphertext=ciphertext,
+    )
+    # Worker prompts list available credential names, so adding one must
+    # invalidate the graph cache.
+    invalidate_graph_cache()
+    row = await db.get_credential_meta(credential_id, user_id)
+    return _credential_view(row)
+
+
+class CredentialUpdate(BaseModel):
+    name: str | None = None
+    # Submitting a value replaces the stored secret. Omit it to leave the
+    # secret untouched (e.g. when only renaming).
+    value: str | None = None
+
+
+@router.put("/api/credentials/{credential_id}")
+async def update_credential(
+    request: Request,
+    credential_id: str,
+    body: CredentialUpdate,
+    user: dict = Depends(require_auth),
+):
+    _require_enabled()
+    db = get_db(request)
+    user_id = get_user_id(request)
+    existing = await db.get_credential_meta(credential_id, user_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Credential not found")
+
+    new_name: str | None = None
+    if body.name is not None:
+        new_name = body.name.strip()
+        if not new_name:
+            raise HTTPException(status_code=400, detail="name must not be empty")
+        if new_name != existing["name"]:
+            other_names = await db.list_credential_names(user_id)
+            if new_name in other_names:
+                raise HTTPException(status_code=409, detail=f"a credential named {new_name!r} already exists")
+
+    ciphertext: bytes | None = None
+    if body.value is not None:
+        if not body.value:
+            raise HTTPException(status_code=400, detail="value must not be empty")
+        ciphertext = encrypt_value(body.value)
+
+    await db.update_credential(
+        credential_id=credential_id,
+        user_id=user_id,
+        name=new_name,
+        value_ciphertext=ciphertext,
+    )
+    if new_name is not None:
+        invalidate_graph_cache()
+    row = await db.get_credential_meta(credential_id, user_id)
+    return _credential_view(row)
+
+
+@router.delete("/api/credentials/{credential_id}")
+async def delete_credential(request: Request, credential_id: str, user: dict = Depends(require_auth)):
+    _require_enabled()
+    db = get_db(request)
+    user_id = get_user_id(request)
+    existing = await db.get_credential_meta(credential_id, user_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    await db.delete_credential(credential_id, user_id)
+    invalidate_graph_cache()
+    return {"ok": True}

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -34,6 +34,41 @@ def test_credentials_disabled_when_key_unset(monkeypatch):
         credentials.decrypt_value(b"anything")
 
 
+def test_seed_can_be_arbitrary_string(monkeypatch):
+    """Any non-empty seed must produce a working Fernet instance.
+
+    This is the property that lets the terraform random_password module
+    feed CREDENTIAL_ENCRYPTION_KEY directly without us needing a
+    Fernet-specific generator.
+    """
+    monkeypatch.setenv("CREDENTIAL_ENCRYPTION_KEY", "any-old-string-from-random-password")
+    credentials._fernet = None
+    credentials._fernet_initialized = False
+    assert credentials.credentials_enabled() is True
+    ct = credentials.encrypt_value("hello")
+    assert credentials.decrypt_value(ct) == "hello"
+
+
+def test_different_seeds_produce_different_keys(monkeypatch):
+    """Two distinct seeds derive to two distinct Fernet keys.
+
+    Verifies the derivation isn't accidentally collapsing to a single key.
+    """
+    monkeypatch.setenv("CREDENTIAL_ENCRYPTION_KEY", "seed-one")
+    credentials._fernet = None
+    credentials._fernet_initialized = False
+    ct = credentials.encrypt_value("payload")
+
+    monkeypatch.setenv("CREDENTIAL_ENCRYPTION_KEY", "seed-two")
+    credentials._fernet = None
+    credentials._fernet_initialized = False
+    # Decrypting with the wrong seed must fail.
+    from cryptography.fernet import InvalidToken
+
+    with pytest.raises(InvalidToken):
+        credentials.decrypt_value(ct)
+
+
 def test_encrypt_decrypt_roundtrip():
     plaintext = "hunter2"
     ct = credentials.encrypt_value(plaintext)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,87 @@
+"""Unit tests for the credentials module.
+
+These cover the security-critical surface: encryption round-trip, fail-closed
+behavior when no key is configured, placeholder substitution, and the
+output redaction backstop.
+"""
+
+import pytest
+from cryptography.fernet import Fernet
+
+from rhiza_agents import credentials
+
+
+@pytest.fixture(autouse=True)
+def _set_encryption_key(monkeypatch):
+    """Install a fresh encryption key for every test."""
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("CREDENTIAL_ENCRYPTION_KEY", key)
+    credentials._fernet = None
+    credentials._fernet_initialized = False
+    yield
+    credentials._fernet = None
+    credentials._fernet_initialized = False
+
+
+def test_credentials_disabled_when_key_unset(monkeypatch):
+    monkeypatch.delenv("CREDENTIAL_ENCRYPTION_KEY", raising=False)
+    credentials._fernet = None
+    credentials._fernet_initialized = False
+    assert credentials.credentials_enabled() is False
+    with pytest.raises(RuntimeError, match="disabled"):
+        credentials.encrypt_value("anything")
+    with pytest.raises(RuntimeError, match="disabled"):
+        credentials.decrypt_value(b"anything")
+
+
+def test_encrypt_decrypt_roundtrip():
+    plaintext = "hunter2"
+    ct = credentials.encrypt_value(plaintext)
+    assert plaintext.encode() not in ct  # not stored verbatim
+    assert credentials.decrypt_value(ct) == plaintext
+
+
+def test_encrypt_value_produces_different_ciphertext_each_call():
+    """Fernet uses a random nonce; identical plaintexts encrypt differently."""
+    a = credentials.encrypt_value("alice")
+    b = credentials.encrypt_value("alice")
+    assert a != b
+
+
+def test_extract_placeholders():
+    template = "machine x login {USER} password {PASSWD}\nliteral {NOT_A_VAR\n"
+    placeholders = credentials.extract_placeholders(template)
+    assert placeholders == ["USER", "PASSWD"]
+
+
+def test_substitute_placeholders_preserves_braces():
+    """Templates may contain literal braces (e.g. JSON) that aren't placeholders."""
+    template = '{"key": "{TOKEN}", "other": "no_placeholder"}'
+    out = credentials.substitute_placeholders(template, {"TOKEN": "abc123"})
+    assert out == '{"key": "abc123", "other": "no_placeholder"}'
+
+
+def test_substitute_unknown_placeholder_left_intact():
+    out = credentials.substitute_placeholders("{KNOWN} and {UNKNOWN}", {"KNOWN": "yes"})
+    assert out == "yes and {UNKNOWN}"
+
+
+def test_redact_output_replaces_all_occurrences():
+    text = "user=alice password=hunter2 retry=hunter2"
+    out = credentials.redact_output(text, ["alice", "hunter2"])
+    assert "alice" not in out
+    assert "hunter2" not in out
+    assert out.count("[REDACTED]") == 3
+
+
+def test_redact_output_handles_empty():
+    assert credentials.redact_output("", ["x"]) == ""
+    assert credentials.redact_output("hello", []) == "hello"
+
+
+def test_redact_output_dedupes_and_orders_by_length():
+    """Longer values redact first so a containing value doesn't leave residue."""
+    text = "abcdef and abc"
+    out = credentials.redact_output(text, ["abc", "abcdef"])
+    assert "abcdef" not in out
+    assert out == "[REDACTED] and [REDACTED]"

--- a/tests/test_sandbox_credentials.py
+++ b/tests/test_sandbox_credentials.py
@@ -7,8 +7,31 @@ async db: validation, name collection, and the env-vars/file build step.
 from rhiza_agents.agents.tools.sandbox import (
     _build_runtime_injection,
     _collect_referenced_names,
+    _normalize_sandbox_upload_path,
     _validate_materializations,
 )
+
+
+def test_normalize_sandbox_upload_path_strips_tilde():
+    """Daytona's fs.upload_file does not expand ``~``; we have to strip it."""
+    assert _normalize_sandbox_upload_path("~/.netrc") == ".netrc"
+
+
+def test_normalize_sandbox_upload_path_strips_home_prefix():
+    """An absolute path under the sandbox home should land at the same place."""
+    assert _normalize_sandbox_upload_path("/root/.netrc") == ".netrc"
+    assert _normalize_sandbox_upload_path("/root/code/foo.py") == "code/foo.py"
+
+
+def test_normalize_sandbox_upload_path_strips_leading_slash():
+    """Absolute paths outside the sandbox home are made relative to it."""
+    assert _normalize_sandbox_upload_path("/home/daytona/foo.py") == "home/daytona/foo.py"
+    assert _normalize_sandbox_upload_path("/.netrc") == ".netrc"
+
+
+def test_normalize_sandbox_upload_path_passes_relative_through():
+    assert _normalize_sandbox_upload_path("code/foo.py") == "code/foo.py"
+    assert _normalize_sandbox_upload_path(".netrc") == ".netrc"
 
 
 def test_validate_rejects_non_list():

--- a/tests/test_sandbox_credentials.py
+++ b/tests/test_sandbox_credentials.py
@@ -1,0 +1,150 @@
+"""Tests for the credential resolution helpers in the sandbox tool.
+
+These cover the pure functions that don't touch the Daytona SDK or the
+async db: validation, name collection, and the env-vars/file build step.
+"""
+
+from rhiza_agents.agents.tools.sandbox import (
+    _build_runtime_injection,
+    _collect_referenced_names,
+    _validate_materializations,
+)
+
+
+def test_validate_rejects_non_list():
+    assert _validate_materializations("nope") is not None
+
+
+def test_validate_accepts_empty_list():
+    assert _validate_materializations([]) is None
+
+
+def test_validate_env_vars_shape():
+    assert _validate_materializations([{"kind": "env_vars", "names": ["A", "B"]}]) is None
+    assert _validate_materializations([{"kind": "env_vars", "names": "A"}]) is not None
+    assert _validate_materializations([{"kind": "env_vars", "names": [""]}]) is not None
+    assert _validate_materializations([{"kind": "env_vars", "names": []}]) is not None
+    assert _validate_materializations([{"kind": "env_vars"}]) is not None
+
+
+def test_validate_file_shape():
+    ok = [
+        {
+            "kind": "file",
+            "path": "~/.netrc",
+            "names": ["U"],
+            "content": "machine x login {U}",
+        }
+    ]
+    assert _validate_materializations(ok) is None
+    # missing path
+    assert _validate_materializations([{"kind": "file", "path": "", "names": ["U"], "content": "x"}]) is not None
+    # missing content
+    assert _validate_materializations([{"kind": "file", "path": "p", "names": ["U"]}]) is not None
+    # missing names
+    assert _validate_materializations([{"kind": "file", "path": "p", "content": "x"}]) is not None
+
+
+def test_validate_file_rejects_undeclared_placeholder():
+    """Placeholders in content must also appear in the explicit names list."""
+    bad = [
+        {
+            "kind": "file",
+            "path": "~/.netrc",
+            "names": ["U"],
+            "content": "machine x login {U} password {P}",
+        }
+    ]
+    err = _validate_materializations(bad)
+    assert err is not None
+    assert "P" in err
+
+
+def test_validate_unknown_kind():
+    assert _validate_materializations([{"kind": "exec_arbitrary", "names": ["X"]}]) is not None
+
+
+def test_collect_names_env_vars():
+    names = _collect_referenced_names([{"kind": "env_vars", "names": ["A", "B", "A"]}])
+    assert names == ["A", "B"]
+
+
+def test_collect_names_file_uses_explicit_list():
+    """file kind's collected names come from the explicit `names` list, not
+    from regexing the content template."""
+    names = _collect_referenced_names(
+        [
+            {
+                "kind": "file",
+                "path": "~/.netrc",
+                "names": ["U", "P"],
+                "content": "{U} and {P}",
+            }
+        ]
+    )
+    assert names == ["U", "P"]
+
+
+def test_collect_names_mixed():
+    names = _collect_referenced_names(
+        [
+            {"kind": "env_vars", "names": ["TAHMO_USER", "TAHMO_PASS"]},
+            {
+                "kind": "file",
+                "path": "~/.netrc",
+                "names": ["NASA_USER", "NASA_PASS"],
+                "content": "machine x login {NASA_USER} password {NASA_PASS}",
+            },
+        ]
+    )
+    assert names == ["TAHMO_USER", "TAHMO_PASS", "NASA_USER", "NASA_PASS"]
+
+
+def test_build_runtime_injection_env_vars():
+    env, files = _build_runtime_injection(
+        [{"kind": "env_vars", "names": ["NASA_USER", "NASA_PASS"]}],
+        {"NASA_USER": "alice", "NASA_PASS": "hunter2"},
+    )
+    assert env == {"NASA_USER": "alice", "NASA_PASS": "hunter2"}
+    assert files == {}
+
+
+def test_build_runtime_injection_file_substitution():
+    env, files = _build_runtime_injection(
+        [
+            {
+                "kind": "file",
+                "path": "~/.netrc",
+                "names": ["U", "P"],
+                "content": "machine x login {U} password {P}\n",
+            }
+        ],
+        {"U": "alice", "P": "hunter2"},
+    )
+    assert env == {}
+    assert files == {"~/.netrc": "machine x login alice password hunter2\n"}
+
+
+def test_build_runtime_injection_concatenates_same_path():
+    """Two file materializations targeting the same path get concatenated
+    in the order the LLM listed them. This is how scripts that need
+    multiple netrc machine entries work."""
+    env, files = _build_runtime_injection(
+        [
+            {
+                "kind": "file",
+                "path": "~/.netrc",
+                "names": ["AU", "AP"],
+                "content": "machine a login {AU} password {AP}\n",
+            },
+            {
+                "kind": "file",
+                "path": "~/.netrc",
+                "names": ["BU", "BP"],
+                "content": "machine b login {BU} password {BP}\n",
+            },
+        ],
+        {"AU": "alice", "AP": "p1", "BU": "bob", "BP": "p2"},
+    )
+    assert env == {}
+    assert files == {"~/.netrc": "machine a login alice password p1\nmachine b login bob password p2\n"}

--- a/uv.lock
+++ b/uv.lock
@@ -2933,6 +2933,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "cryptography" },
     { name = "databases", extra = ["aiosqlite"] },
     { name = "fastapi" },
     { name = "httpx" },
@@ -2979,6 +2980,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "authlib" },
+    { name = "cryptography", specifier = ">=46.0.5" },
     { name = "databases", extras = ["aiosqlite"] },
     { name = "databases", extras = ["asyncpg"], marker = "extra == 'postgres'" },
     { name = "daytona-sdk", marker = "extra == 'sandbox'", specifier = ">=0.149.0" },


### PR DESCRIPTION
## Summary

- New per-user encrypted credential store. Each credential is a flat (name, value) pair encrypted at rest with a key derived from `CREDENTIAL_ENCRYPTION_KEY` (any high-entropy random string; SHA-256 hashed at startup). Feature fails closed when the env var is unset.
- `run_file` accepts a `credentials` argument: a list of materialization plans of kind `env_vars` (list of names exposed as same-named env vars) or `file` (path + content template + explicit `names` list, with `{NAME}` placeholders substituted from the named secrets). Plans match the shape of the `requires_credentials` frontmatter the LLM reads from `get_data` responses, so the LLM is just a courier — no interpretation.
- Per-execution injection: env vars via `CodeRunParams.env`, files uploaded immediately before the run and removed after. Nothing persists across runs.
- HITL approval card extended with a flat list of stored credential names this run will access. Users verify the names match the script before approving.
- Output redaction backstop scrubs verbatim secret values from stdout/stderr and captured file contents before they reach the LLM.
- Settings UI gains a Credentials section: list, add, edit, delete. Values are never shown back; submitting an empty value during edit leaves the stored value unchanged.
- Implements #24 — see the issue body and the deviation comment for the design rationale (collapsed the original "typed credentials + bindings + three trust layers" model down to flat name/value pairs and the LLM-as-bridge pattern).

closes #24

## Test plan

- [x] `uv run pytest` — all 23 tests pass (`test_credentials.py` covers encryption round-trip, fail-closed, seed derivation, redaction; `test_sandbox_credentials.py` covers materialization plan validation, name collection, env_vars + file + same-path concatenation)
- [x] `uv run ruff check src/rhiza_agents tests` — clean
- [x] App boots locally with `CREDENTIAL_ENCRYPTION_KEY` set; `/api/credentials` returns 200 (authenticated) instead of 503
- [ ] App boots locally with `CREDENTIAL_ENCRYPTION_KEY` unset; `/api/credentials` returns 503
- [x] Settings UI: add a credential, edit its value, edit only its name, delete it
- [x] In a chat with the Code Runner, ask the LLM to write and run a script that needs an env var stored as a credential. The HITL approval card shows the secret name. After approval, the script runs with the env var set; output containing the value is redacted.
- [x] Same flow but with a `file` materialization (e.g. `~/.netrc`): the file appears at the right path inside the sandbox during the run and is removed after.

## Companion changes

This PR depends on the matching `requires_credentials` frontmatter section added to the [skill-via-mcp specification](https://github.com/rhiza-research/skill-via-mcp).