### PR TITLE
feat: auto-load skill scripts into file state and accept CLI args in run_file

### DIFF
--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import logging
+import shlex
 from datetime import UTC, datetime
 
 from langchain_core.messages import ToolMessage
@@ -21,6 +22,18 @@ logger = logging.getLogger(__name__)
 
 # Maximum file size in bytes (1MB)
 _MAX_FILE_SIZE = 1_000_000
+
+
+def _build_uv_run_cmd(filename: str, script_args: list[str] | None) -> str:
+    """Build the ``uv run ...`` shell command with each arg shell-quoted.
+
+    Pure helper — extracted so the command-building logic can be tested
+    independently of the Daytona sandbox.
+    """
+    if not script_args:
+        return f"uv run {filename}"
+    suffix = " ".join(shlex.quote(a) for a in script_args)
+    return f"uv run {filename} {suffix}"
 
 
 @tool
@@ -92,6 +105,7 @@ def make_run_file(db=None):
     @tool
     async def run_file(
         path: str,
+        script_args: list[str] | None = None,
         credentials: list[dict] | None = None,
         *,
         runtime: ToolRuntime,
@@ -100,7 +114,8 @@ def make_run_file(db=None):
 
         Reads the file content from state and runs it in the code sandbox
         via ``uv run`` (which honors PEP 723 inline script dependencies).
-        The file must already exist (written via ``write_file``).
+        The file must already exist (written via ``write_file`` or loaded
+        into state by a skill activation).
 
         This is the preferred way to run any non-trivial code that the user
         should be able to review. Always go through ``write_file`` →
@@ -109,6 +124,11 @@ def make_run_file(db=None):
 
         Args:
             path: Path of the file to execute (e.g., '/code/analysis.py').
+            script_args: Optional list of CLI arguments passed after the
+                script path, e.g. ``["--date", "2026-02-15", "--region",
+                "africa", "--output", "/tmp/out.zarr"]``. Each element is
+                passed as a single token; no shell interpretation. Omit or
+                pass ``None`` to run with no arguments.
             credentials: Optional list of materialization plans describing
                 which stored secrets to make available to this run. Same
                 shape as ``execute_python_code``'s ``credentials`` argument:
@@ -216,13 +236,15 @@ def make_run_file(db=None):
             except Exception:
                 pre_files = set()
 
+            cmd = _build_uv_run_cmd(filename, script_args)
+
             # sandbox.process.exec accepts an env dict that's merged into
             # the process environment for this single command, which is
             # exactly the per-execution scoping we want for credentials.
             if env_vars:
-                response = sandbox.process.exec(f"uv run {filename}", env=dict(env_vars))
+                response = sandbox.process.exec(cmd, env=dict(env_vars))
             else:
-                response = sandbox.process.exec(f"uv run {filename}")
+                response = sandbox.process.exec(cmd)
 
             # Discover new files created during execution
             new_files = {}

--- a/src/rhiza_agents/agents/tools/skills.py
+++ b/src/rhiza_agents/agents/tools/skills.py
@@ -13,9 +13,13 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 
 import yaml
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import StructuredTool
+from langgraph.prebuilt import ToolRuntime
+from langgraph.types import Command
 
 logger = logging.getLogger(__name__)
 
@@ -76,11 +80,22 @@ def parse_skill_md(content: str) -> ParsedSkill:
     )
 
 
+def _parsed_scripts(skill_record: dict) -> dict[str, str]:
+    """Return the bundled-scripts dict (filename -> content) or empty dict."""
+    scripts_json = skill_record.get("scripts_json")
+    if not scripts_json:
+        return {}
+    if isinstance(scripts_json, str):
+        return json.loads(scripts_json)
+    return dict(scripts_json)
+
+
 def _build_activation_response(skill_record: dict) -> str:
     """Build the full activation response for a skill tool call.
 
-    Returns the full prompt + references content. Scripts are noted
-    but written to sandbox separately.
+    Returns the full prompt + references content. Bundled scripts are
+    loaded into the file state by the tool function itself; here we just
+    note where to find them so the agent can call ``run_file``.
     """
     parsed = parse_skill_md(skill_record["skill_md"])
     parts = [parsed.prompt]
@@ -92,13 +107,16 @@ def _build_activation_response(skill_record: dict) -> str:
         for filename, content in refs.items():
             parts.append(f"\n\n---\n## Reference: {filename}\n\n{content}")
 
-    # Note available scripts
-    scripts_json = skill_record.get("scripts_json")
-    if scripts_json:
-        scripts = json.loads(scripts_json) if isinstance(scripts_json, str) else scripts_json
-        if scripts:
-            script_list = ", ".join(f"`scripts/{name}`" for name in scripts)
-            parts.append(f"\n\n---\nAvailable scripts (already written to sandbox): {script_list}")
+    scripts = _parsed_scripts(skill_record)
+    if scripts:
+        prefix = f"/skills/{parsed.name}/scripts"
+        paths = ", ".join(f"`{prefix}/{name}`" for name in scripts)
+        parts.append(
+            "\n\n---\nBundled scripts are loaded into the conversation filesystem "
+            f"at: {paths}. Execute them with the `run_file` tool (e.g. "
+            f"`run_file('{prefix}/{next(iter(scripts))}')`). The scripts use "
+            "PEP 723 inline metadata so `uv run` resolves their dependencies."
+        )
 
     return "\n".join(parts)
 
@@ -167,18 +185,47 @@ def create_skill_tool(skill_record: dict) -> StructuredTool:
     """Create a LangChain tool for a skill.
 
     Tool description = skill's short description (loaded at graph build time).
-    Tool return value = full prompt + references + script info (progressive disclosure).
+    On activation the tool returns a Command that:
+    - Emits the full prompt + reference contents as a ToolMessage.
+    - Loads every bundled script from ``scripts_json`` into the graph's
+      ``files`` state under ``/skills/<skill-name>/scripts/<filename>`` so
+      the agent can call ``run_file`` on them immediately. ``run_file`` then
+      uploads the file content to the Daytona sandbox and executes via
+      ``uv run``. Namespacing by skill name prevents filename collisions
+      across skills (e.g. multiple fetchers each shipping a ``fetch.py``).
     """
     parsed = parse_skill_md(skill_record["skill_md"])
     skill_id = skill_record["id"]
     record = skill_record  # Capture for closure
+    scripts = _parsed_scripts(record)
+    script_path_prefix = f"/skills/{parsed.name}/scripts"
 
-    def _activate() -> str:
-        """Activate this skill and get detailed instructions."""
-        return _build_activation_response(record)
+    async def _activate(*, runtime: ToolRuntime) -> Command:
+        """Activate this skill and load any bundled scripts into file state."""
+        prompt = _build_activation_response(record)
+        update: dict = {"messages": [ToolMessage(content=prompt, tool_call_id=runtime.tool_call_id)]}
+        if scripts:
+            now = datetime.now(UTC).isoformat()
+            files_update: dict = {}
+            for filename, content in scripts.items():
+                # Content is stored as a single string; split into lines to
+                # match the shape used by write_file.
+                if isinstance(content, list):
+                    lines = content
+                else:
+                    lines = str(content).split("\n")
+                files_update[f"{script_path_prefix}/{filename}"] = {
+                    "content": lines,
+                    "source": "skill",
+                    "skill_id": skill_id,
+                    "created_at": now,
+                    "modified_at": now,
+                }
+            update["files"] = files_update
+        return Command(update=update)
 
     tool = StructuredTool.from_function(
-        func=_activate,
+        coroutine=_activate,
         name=f"skill_{parsed.name.replace('-', '_')}",
         description=f"Skill: {parsed.description}",
     )

--- a/tests/test_run_file_args.py
+++ b/tests/test_run_file_args.py
@@ -1,0 +1,79 @@
+"""Tests for run_file's shell-safe CLI argument passthrough.
+
+Covers the pure command-builder helper. The rest of run_file hits the
+Daytona sandbox so isn't exercised here.
+"""
+
+import shlex
+
+import pytest
+
+from rhiza_agents.agents.tools.files import _build_uv_run_cmd
+
+
+def test_no_args_produces_bare_uv_run():
+    assert _build_uv_run_cmd("script.py", None) == "uv run script.py"
+
+
+def test_empty_list_treated_as_no_args():
+    assert _build_uv_run_cmd("script.py", []) == "uv run script.py"
+
+
+def test_simple_args_appended():
+    cmd = _build_uv_run_cmd("script.py", ["--date", "2026-02-15", "--region", "kenya"])
+    assert cmd == "uv run script.py --date 2026-02-15 --region kenya"
+
+
+def test_value_with_space_is_quoted():
+    cmd = _build_uv_run_cmd("p.py", ["--title", "hello world"])
+    # shlex.quote will wrap the value in single quotes.
+    assert cmd == "uv run p.py --title 'hello world'"
+    # And the quoted form parses back to the original token.
+    tokens = shlex.split(cmd)
+    assert tokens == ["uv", "run", "p.py", "--title", "hello world"]
+
+
+def test_value_with_single_quote_is_escaped():
+    cmd = _build_uv_run_cmd("p.py", ["--name", "it's fine"])
+    tokens = shlex.split(cmd)
+    assert tokens[-1] == "it's fine"
+
+
+def test_path_with_spaces_quoted():
+    cmd = _build_uv_run_cmd("p.py", ["--out", "/tmp/a b/c.png"])
+    tokens = shlex.split(cmd)
+    assert tokens[-2:] == ["--out", "/tmp/a b/c.png"]
+
+
+@pytest.mark.parametrize(
+    "hazard",
+    [
+        "*.nc",
+        "; rm -rf /",
+        "`whoami`",
+        "$(cat /etc/passwd)",
+        "foo && bar",
+        "foo | bar",
+        "< /etc/shadow",
+        "> /tmp/evil",
+    ],
+)
+def test_shell_metacharacters_are_not_interpreted(hazard):
+    """Dangerous shell chars must pass through as literal argv tokens."""
+    cmd = _build_uv_run_cmd("p.py", ["--arg", hazard])
+    tokens = shlex.split(cmd)
+    # The hazardous value must survive intact as a single token.
+    assert tokens[-1] == hazard
+    # And must be quoted (not a bare unquoted char).
+    assert shlex.quote(hazard) in cmd
+
+
+def test_filename_with_space_not_quoted_by_us():
+    """We don't quote the filename because it comes from our own path
+    normalization, not user input. Document that contract in a test."""
+    # If this ever breaks, filename must also be shlex.quote()'d to keep
+    # the invariant. Currently our filenames come from
+    # _normalize_sandbox_upload_path which strips leading slashes and
+    # never produces spaces.
+    cmd = _build_uv_run_cmd("code/ok.py", None)
+    assert cmd == "uv run code/ok.py"

--- a/tests/test_skills_activation.py
+++ b/tests/test_skills_activation.py
@@ -1,0 +1,208 @@
+"""Tests for skill tool activation (Agent Skills support).
+
+Covers the pure parsing helpers and the activation Command built by
+``create_skill_tool`` — no sandbox, no LangGraph graph build.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from rhiza_agents.agents.tools.skills import (
+    _build_activation_response,
+    _parsed_scripts,
+    create_skill_tool,
+)
+
+SKILL_MD_MINIMAL = """---
+name: hello-skill
+description: A demo skill that prints hello. Use when demoing.
+---
+# Hello
+
+Body content.
+"""
+
+SKILL_MD_WITH_REFS = """---
+name: ref-skill
+description: A skill with reference docs.
+---
+# Ref
+
+Body.
+"""
+
+
+def _record(skill_md=SKILL_MD_MINIMAL, scripts=None, refs=None):
+    return {
+        "id": "sk-test",
+        "skill_md": skill_md,
+        "scripts_json": scripts,
+        "references_json": refs,
+        "assets_json": None,
+    }
+
+
+# -- _parsed_scripts -----------------------------------------------------
+
+
+def test_parsed_scripts_none():
+    assert _parsed_scripts(_record(scripts=None)) == {}
+
+
+def test_parsed_scripts_empty_dict():
+    assert _parsed_scripts(_record(scripts={})) == {}
+
+
+def test_parsed_scripts_dict_input():
+    out = _parsed_scripts(_record(scripts={"a.py": "print(1)", "b.py": "print(2)"}))
+    assert out == {"a.py": "print(1)", "b.py": "print(2)"}
+
+
+def test_parsed_scripts_json_string_input():
+    raw = json.dumps({"fetch.py": "x = 1"})
+    out = _parsed_scripts(_record(scripts=raw))
+    assert out == {"fetch.py": "x = 1"}
+
+
+# -- _build_activation_response ------------------------------------------
+
+
+def test_activation_response_contains_body():
+    resp = _build_activation_response(_record())
+    assert "# Hello" in resp
+    assert "Body content." in resp
+
+
+def test_activation_response_inlines_references():
+    refs = json.dumps({"ENVELOPE.md": "# Envelope\nSpec body."})
+    resp = _build_activation_response(_record(refs=refs))
+    assert "## Reference: ENVELOPE.md" in resp
+    assert "Spec body." in resp
+
+
+def test_activation_response_mentions_each_script_path():
+    resp = _build_activation_response(_record(scripts={"fetch.py": "print(1)", "plot.py": "print(2)"}))
+    # Paths are namespaced by skill name to avoid collisions across skills.
+    assert "/skills/hello-skill/scripts/fetch.py" in resp
+    assert "/skills/hello-skill/scripts/plot.py" in resp
+    assert "run_file" in resp
+
+
+def test_activation_response_has_no_script_note_when_empty():
+    resp = _build_activation_response(_record())
+    assert "/scripts/" not in resp
+    assert "/skills/" not in resp
+
+
+# -- create_skill_tool + activation Command ------------------------------
+
+
+def _activate(tool, state=None):
+    runtime = SimpleNamespace(tool_call_id="call-xyz", state=state or {})
+    return asyncio.run(tool.coroutine(runtime=runtime))
+
+
+def test_tool_name_and_description():
+    tool = create_skill_tool(_record())
+    assert tool.name == "skill_hello_skill"
+    assert tool.description == "Skill: A demo skill that prints hello. Use when demoing."
+
+
+def test_tool_metadata_no_scripts():
+    tool = create_skill_tool(_record())
+    assert tool.metadata["skill_id"] == "sk-test"
+    assert tool.metadata["requires_sandbox"] is False
+
+
+def test_tool_metadata_with_scripts_requires_sandbox():
+    tool = create_skill_tool(_record(scripts={"a.py": "pass"}))
+    assert tool.metadata["requires_sandbox"] is True
+
+
+def test_activation_command_no_scripts_has_only_messages():
+    tool = create_skill_tool(_record())
+    cmd = _activate(tool)
+    assert "files" not in cmd.update
+    assert len(cmd.update["messages"]) == 1
+    msg = cmd.update["messages"][0]
+    assert msg.tool_call_id == "call-xyz"
+    assert "# Hello" in msg.content
+
+
+def test_activation_command_loads_scripts_into_files():
+    tool = create_skill_tool(_record(scripts={"fetch.py": "print('hi')\n", "plot.py": "print('bye')"}))
+    cmd = _activate(tool)
+    files = cmd.update["files"]
+    # Paths are namespaced under /skills/<skill-name>/scripts so that
+    # multiple skills shipping the same filename (e.g. four fetchers each
+    # with a fetch.py) don't collide in the file state.
+    assert set(files.keys()) == {
+        "/skills/hello-skill/scripts/fetch.py",
+        "/skills/hello-skill/scripts/plot.py",
+    }
+    # Stored as a list of lines, matching write_file's shape.
+    assert files["/skills/hello-skill/scripts/fetch.py"]["content"] == ["print('hi')", ""]
+    assert files["/skills/hello-skill/scripts/plot.py"]["content"] == ["print('bye')"]
+    # Metadata stamped for provenance.
+    for entry in files.values():
+        assert entry["source"] == "skill"
+        assert entry["skill_id"] == "sk-test"
+        assert "created_at" in entry and "modified_at" in entry
+
+
+def test_activation_namespaces_by_skill_name():
+    """Two skills with a filename collision must not stomp each other."""
+    ecmwf = create_skill_tool(
+        {
+            "id": "sk-ecmwf",
+            "skill_md": "---\nname: ecmwf-fetch\ndescription: ECMWF fetcher.\n---\nbody\n",
+            "scripts_json": {"fetch.py": "print('ecmwf')"},
+        }
+    )
+    chirps = create_skill_tool(
+        {
+            "id": "sk-chirps",
+            "skill_md": "---\nname: chirps-fetch\ndescription: CHIRPS fetcher.\n---\nbody\n",
+            "scripts_json": {"fetch.py": "print('chirps')"},
+        }
+    )
+    e_files = _activate(ecmwf).update["files"]
+    c_files = _activate(chirps).update["files"]
+    assert "/skills/ecmwf-fetch/scripts/fetch.py" in e_files
+    assert "/skills/chirps-fetch/scripts/fetch.py" in c_files
+    # Crucially they land at distinct paths so activating both in the same
+    # conversation keeps both scripts available.
+    assert set(e_files).isdisjoint(set(c_files))
+
+
+def test_activation_preserves_script_content_passed_as_list():
+    # If the DB serializer ever stores content pre-split, we should still
+    # round-trip without double-splitting or mangling.
+    tool = create_skill_tool(_record(scripts={"a.py": ["line1", "line2"]}))
+    cmd = _activate(tool)
+    assert cmd.update["files"]["/skills/hello-skill/scripts/a.py"]["content"] == ["line1", "line2"]
+
+
+def test_activation_tool_message_names_every_script():
+    tool = create_skill_tool(_record(scripts={"a.py": "pass", "b.py": "pass"}))
+    cmd = _activate(tool)
+    content = cmd.update["messages"][0].content
+    assert "/skills/hello-skill/scripts/a.py" in content
+    assert "/skills/hello-skill/scripts/b.py" in content
+
+
+@pytest.mark.parametrize(
+    "bad_md",
+    [
+        "no frontmatter",
+        "---\nname: x\n---\nno description",
+        "---\ndescription: x\n---\nno name",
+        "---\nname: Bad Name\ndescription: x\n---\nbad name case",
+    ],
+)
+def test_create_skill_tool_rejects_invalid_skill_md(bad_md):
+    with pytest.raises(ValueError):
+        create_skill_tool({"id": "x", "skill_md": bad_md})


### PR DESCRIPTION
## Summary

Two related changes that make skills-with-bundled-scripts (per the [agentskills.io](https://agentskills.io) spec) executable end-to-end through the existing `write_file` / `run_file` flow.

### skills: load bundled scripts into file state on activation

`create_skill_tool` now returns a `Command` that populates `state["files"]` with every entry from `scripts_json` under `/skills/<skill-name>/scripts/<filename>`. The activation message previously claimed scripts were *"already written to sandbox"* when no code path actually did that; it now points at the real paths and names `run_file` as the executor.

Paths are **namespaced by skill name** because multiple skills commonly ship a `fetch.py` (e.g. `ecmwf-fetch`, `chirps-fetch`, `imerg-fetch`, `tahmo-fetch`). A flat `/scripts/<filename>` would let them stomp each other in the conversation file state.

The existing `_merge_files` reducer in the graph state schema merges the update in cleanly; no graph-level changes needed.

### files: `run_file` accepts `script_args` for CLI-style scripts

Skills written as argparse/CLI tools need argument passthrough. Added an optional `script_args: list[str]` parameter to `run_file`; each arg is shell-quoted via `shlex.quote` and appended to `uv run <filename>`. Extracted `_build_uv_run_cmd` as a pure helper so the quoting logic is testable without touching the Daytona SDK.

Named the param `script_args` rather than `args` because `args` collides with `@tool`'s internal variadic-arg handling and silently drops from the input schema (discovered the hard way).

### End-to-end usage

When an agent activates a skill like `rhiza-research/forecasting-skills` `ecmwf-fetch`:

1. `skill_ecmwf_fetch` tool call — SKILL.md prompt returned plus `/skills/ecmwf-fetch/scripts/fetch.py` lands in state.
2. Agent calls `run_file(path="/skills/ecmwf-fetch/scripts/fetch.py", script_args=["--date", "2026-02-13", "--region", "kenya", "--output", "/tmp/ecmwf.zarr"], credentials=[{"kind":"env_vars","names":["ECMWF_API_URL","ECMWF_API_KEY","ECMWF_API_EMAIL"]}])`.
3. Sandbox uploads the script, runs `uv run /skills/ecmwf-fetch/scripts/fetch.py --date 2026-02-13 --region kenya --output /tmp/ecmwf.zarr` with creds in env.
4. Output files surfaced back into state.

## Test plan

- [x] 35 new unit tests, all passing (62 total)
- [x] Skills parsing: `_parsed_scripts` / `_build_activation_response` across None / empty / JSON-string / dict inputs
- [x] `create_skill_tool` Command shape with and without scripts
- [x] Script content preserved for both `str` and pre-split `list` inputs
- [x] Per-file metadata (`source="skill"`, `skill_id`, timestamps) stamped on every loaded script
- [x] Explicit collision test: two skills with the same script filename land at distinct paths
- [x] `_build_uv_run_cmd` exercised against shell-metacharacter hazards (globs, backticks, `$(...)`, logical-AND, pipes, redirects) — they pass through as literal argv tokens
- [x] `ruff check` plus `ruff format` clean
- [ ] Manual verification against a real skills repo after merge

## Notes

Relates to spec #3 "Agent Skills". This is the missing piece that makes bundled-script skills actually runnable.
