### PR TITLE
feat: bulk skill install with discover, refresh, and SHA pinning

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -42,7 +42,10 @@ persistence:
 # Name of the Kubernetes secret containing sensitive env vars.
 # This secret is created by Terraform, NOT by this chart.
 # Keys: KEYCLOAK_CLIENT_SECRET, ANTHROPIC_API_KEY, DAYTONA_API_KEY, DAYTONA_API_URL,
-#       DAYTONA_SANDBOX_DISK_GIB (optional), SECRET_KEY, LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY
+#       DAYTONA_SANDBOX_DISK_GIB (optional), SECRET_KEY, CREDENTIAL_ENCRYPTION_KEY,
+#       LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY,
+#       GITHUB_TOKEN (optional — raises GitHub quota for skill install/refresh from
+#       60/hr anonymous to 5000/hr; a read-only PAT with `public_repo` is sufficient)
 secretName: rhiza-agents-secrets
 
 # Non-secret environment variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,11 @@ services:
       # When unset the credentials feature is disabled and credential API
       # routes return 503.
       CREDENTIAL_ENCRYPTION_KEY: ${CREDENTIAL_ENCRYPTION_KEY:-}
+      # Optional GitHub PAT used by the skill discover/install/refresh routes.
+      # Anonymous works (60/hr per IP); set this to raise the quota to 5000/hr
+      # — useful for bulk install or repeated refreshes. A read-only `public_repo`
+      # PAT is enough for public skill repos.
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     depends_on:
       - keycloak
       - sheerwater-mcp

--- a/frontend/src/widgets/config.ts
+++ b/frontend/src/widgets/config.ts
@@ -96,11 +96,22 @@ export class ConfigWidget extends Widget {
         this._skillList.className = 'vectorstore-list';
         sidebar.appendChild(this._skillList);
 
+        const skillBtnRow = document.createElement('div');
+        skillBtnRow.style.display = 'flex';
+        skillBtnRow.style.gap = '0.5rem';
         const addSkillBtn = document.createElement('button');
         addSkillBtn.className = 'config-btn';
         addSkillBtn.textContent = '+ Add Skill';
+        addSkillBtn.style.flex = '1';
         addSkillBtn.addEventListener('click', () => this._showNewSkillMenu());
-        sidebar.appendChild(addSkillBtn);
+        skillBtnRow.appendChild(addSkillBtn);
+        const refreshAllBtn = document.createElement('button');
+        refreshAllBtn.className = 'config-btn';
+        refreshAllBtn.textContent = '⟳ Refresh All';
+        refreshAllBtn.title = 'Re-pull all GitHub-installed skills from upstream';
+        refreshAllBtn.addEventListener('click', () => this._refreshAllSkills(refreshAllBtn));
+        skillBtnRow.appendChild(refreshAllBtn);
+        sidebar.appendChild(skillBtnRow);
 
         const mcpTitle = document.createElement('h3');
         mcpTitle.className = 'config-sidebar-title';
@@ -529,8 +540,10 @@ export class ConfigWidget extends Widget {
             info.appendChild(name);
             const meta = document.createElement('span');
             meta.className = 'vs-list-count';
-            const sourceLabel = skill.system ? 'system' : skill.source;
-            meta.textContent = sourceLabel + (skill.requires_sandbox ? ' · requires sandbox' : '');
+            const parts = [skill.system ? 'system' : skill.source];
+            if (skill.source_sha) parts.push(skill.source_sha.slice(0, 7));
+            if (skill.requires_sandbox) parts.push('requires sandbox');
+            meta.textContent = parts.join(' · ');
             info.appendChild(meta);
             item.appendChild(info);
 
@@ -543,6 +556,15 @@ export class ConfigWidget extends Widget {
             viewBtn.addEventListener('click', () => this._viewSkill(skill.id));
             actions.appendChild(viewBtn);
 
+            if (!skill.system && skill.source === 'github') {
+                const refreshBtn = document.createElement('button');
+                refreshBtn.className = 'config-btn-sm';
+                refreshBtn.textContent = '⟳';
+                refreshBtn.title = 'Refresh from upstream';
+                refreshBtn.addEventListener('click', () => this._refreshSkill(skill, refreshBtn));
+                actions.appendChild(refreshBtn);
+            }
+
             if (!skill.system) {
                 const delBtn = document.createElement('button');
                 delBtn.className = 'config-btn-sm config-btn-danger';
@@ -554,6 +576,61 @@ export class ConfigWidget extends Widget {
 
             item.appendChild(actions);
             this._skillList.appendChild(item);
+        }
+    }
+
+    private async _refreshSkill(skill: any, btn: HTMLButtonElement): Promise<void> {
+        const original = btn.textContent;
+        btn.textContent = '…';
+        btn.disabled = true;
+        try {
+            const res = await fetch(`/api/skills/${skill.id}/refresh`, { method: 'POST' });
+            const result = await res.json();
+            if (!res.ok) {
+                alert(result.detail || 'Refresh failed');
+                return;
+            }
+            if (result.status === 'updated') {
+                await this._loadSkills();
+            } else if (result.status === 'unchanged') {
+                btn.textContent = '✓';
+                setTimeout(() => { btn.textContent = original; btn.disabled = false; }, 1200);
+                return;
+            } else if (result.status === 'error') {
+                alert(`Refresh failed: ${result.error}`);
+            }
+        } catch (e) {
+            alert(`Refresh failed: ${e}`);
+        }
+        btn.textContent = original;
+        btn.disabled = false;
+    }
+
+    private async _refreshAllSkills(btn: HTMLButtonElement): Promise<void> {
+        const original = btn.textContent;
+        btn.textContent = 'Refreshing…';
+        btn.disabled = true;
+        try {
+            const res = await fetch('/api/skills/refresh', { method: 'POST' });
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                alert(err.detail || 'Refresh failed');
+                return;
+            }
+            const result = await res.json();
+            const lines = [
+                `Updated: ${result.updated.length}`,
+                `Unchanged: ${result.unchanged.length}`,
+            ];
+            if (result.errors.length) lines.push(`Errors: ${result.errors.length}`);
+            if (result.skipped.length) lines.push(`Skipped: ${result.skipped.length}`);
+            alert(lines.join('\n'));
+            if (result.updated.length) await this._loadSkills();
+        } catch (e) {
+            alert(`Refresh failed: ${e}`);
+        } finally {
+            btn.textContent = original;
+            btn.disabled = false;
         }
     }
 
@@ -604,54 +681,207 @@ export class ConfigWidget extends Widget {
     private _showInstallSkillForm(): void {
         this._detail.innerHTML = `
             <div class="config-form">
-                <h2>Install Skill from GitHub</h2>
+                <h2>Install Skills from GitHub</h2>
                 <div class="form-group">
                     <label for="skill-repo">Repository (owner/repo)</label>
-                    <input type="text" id="skill-repo" placeholder="anthropics/skills">
+                    <input type="text" id="skill-repo" placeholder="rhiza-research/forecasting-skills">
                 </div>
                 <div class="form-group">
-                    <label for="skill-path">Path (optional subdirectory)</label>
-                    <input type="text" id="skill-path" placeholder="skills/data-cleaning">
+                    <label for="skill-path">Path (single skill, or directory of skills)</label>
+                    <input type="text" id="skill-path" placeholder="skills">
+                </div>
+                <div class="form-group">
+                    <label for="skill-ref">Branch / tag / SHA (optional)</label>
+                    <input type="text" id="skill-ref" placeholder="main">
                 </div>
                 <div class="config-form-actions">
                     <button id="cancel-skill-btn" class="config-btn">Cancel</button>
-                    <button id="install-skill-btn" class="config-btn config-btn-primary">Install</button>
+                    <button id="search-skill-btn" class="config-btn config-btn-primary">Search</button>
                 </div>
+                <div id="skill-discover-results"></div>
             </div>
         `;
 
         this._detail.querySelector('#cancel-skill-btn')!.addEventListener('click', () => this._renderPlaceholder());
-        this._detail.querySelector('#install-skill-btn')!.addEventListener('click', async () => {
-            const repo = (this._detail.querySelector('#skill-repo') as HTMLInputElement).value.trim();
-            const path = (this._detail.querySelector('#skill-path') as HTMLInputElement).value.trim();
-            if (!repo) return;
+        this._detail.querySelector('#search-skill-btn')!.addEventListener('click', () => this._discoverSkills());
+    }
 
-            const btn = this._detail.querySelector('#install-skill-btn') as HTMLButtonElement;
-            btn.textContent = 'Installing...';
-            btn.disabled = true;
+    private async _discoverSkills(): Promise<void> {
+        const repo = (this._detail.querySelector('#skill-repo') as HTMLInputElement).value.trim();
+        const path = (this._detail.querySelector('#skill-path') as HTMLInputElement).value.trim();
+        const ref = (this._detail.querySelector('#skill-ref') as HTMLInputElement).value.trim();
+        if (!repo) return;
 
-            try {
-                const res = await fetch('/api/skills/install', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ repo, path: path || undefined }),
-                });
-                if (!res.ok) {
-                    const err = await res.json();
-                    alert(err.detail || 'Install failed');
-                    btn.textContent = 'Install';
-                    btn.disabled = false;
-                    return;
-                }
-                await this._loadSkills();
-                await this._loadToolTypes();
-                if (this._selectedAgentId) this._selectAgent(this._selectedAgentId);
-                this._renderPlaceholder();
-            } catch {
-                btn.textContent = 'Error';
-                setTimeout(() => { btn.textContent = 'Install'; btn.disabled = false; }, 2000);
+        const btn = this._detail.querySelector('#search-skill-btn') as HTMLButtonElement;
+        const results = this._detail.querySelector('#skill-discover-results') as HTMLDivElement;
+        btn.textContent = 'Searching…';
+        btn.disabled = true;
+        results.innerHTML = '';
+
+        try {
+            const res = await fetch('/api/skills/discover', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    repo,
+                    path: path || undefined,
+                    ref: ref || undefined,
+                }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                results.innerHTML = `<p style="color: var(--error, #c33);">${escapeHtml(data.detail || 'Discover failed')}</p>`;
+                return;
             }
-        });
+            this._renderDiscoverResults(repo, ref, data, results);
+        } catch (e) {
+            results.innerHTML = `<p style="color: var(--error, #c33);">${escapeHtml(String(e))}</p>`;
+        } finally {
+            btn.textContent = 'Search';
+            btn.disabled = false;
+        }
+    }
+
+    private _renderDiscoverResults(
+        repo: string,
+        ref: string,
+        data: any,
+        container: HTMLDivElement,
+    ): void {
+        const sha = data.source_sha as string;
+        const branch = data.source_branch as string;
+        const available = data.available as any[];
+        const skipped = data.skipped as any[];
+
+        if (!available.length && !skipped.length) {
+            container.innerHTML = '<p style="color: var(--text-secondary);">No skills found at that path.</p>';
+            return;
+        }
+
+        let html = `
+            <p style="color: var(--text-secondary); margin-top: 1rem;">
+              Found ${available.length} skill${available.length === 1 ? '' : 's'} on
+              <code>${escapeHtml(branch)}</code> at <code>${escapeHtml(sha.slice(0, 7))}</code>.
+            </p>
+        `;
+
+        if (available.length) {
+            html += '<div style="display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;">';
+            for (const skill of available) {
+                const installed = skill.already_installed;
+                const isInstalled = !!installed;
+                const sameSha = isInstalled && installed.sha === sha;
+                const tag = isInstalled
+                    ? (sameSha
+                        ? `<span style="color: var(--text-secondary); font-size: 0.85em;">already installed at ${escapeHtml(sha.slice(0, 7))}</span>`
+                        : `<span style="color: var(--text-secondary); font-size: 0.85em;">installed at ${escapeHtml((installed.sha || '?').slice(0, 7))}, ${escapeHtml(sha.slice(0, 7))} available</span>`)
+                    : '';
+                html += `
+                    <label style="display: flex; gap: 0.5rem; align-items: flex-start; cursor: pointer;">
+                        <input type="checkbox"
+                               class="skill-discover-check"
+                               data-subpath="${escapeHtml(skill.subpath)}"
+                               data-installed="${isInstalled ? '1' : '0'}"
+                               ${isInstalled && sameSha ? '' : 'checked'}>
+                        <span>
+                            <strong>${escapeHtml(skill.name)}</strong>
+                            ${skill.has_scripts ? '<span style="color: var(--text-secondary); font-size: 0.85em;"> · has scripts</span>' : ''}
+                            ${tag}
+                            <br>
+                            <span style="color: var(--text-secondary); font-size: 0.9em;">${escapeHtml(skill.description)}</span>
+                        </span>
+                    </label>
+                `;
+            }
+            html += '</div>';
+        }
+
+        if (skipped.length) {
+            html += '<details style="margin-top: 0.75rem;"><summary style="color: var(--text-secondary); font-size: 0.9em;">Skipped ' + skipped.length + '</summary><ul style="font-size: 0.85em; color: var(--text-secondary);">';
+            for (const sk of skipped) {
+                html += `<li><code>${escapeHtml(sk.subpath)}</code> — ${escapeHtml(sk.reason)}</li>`;
+            }
+            html += '</ul></details>';
+        }
+
+        if (available.length) {
+            html += `
+                <div class="config-form-actions" style="margin-top: 1rem;">
+                    <label style="margin-right: auto; display: flex; align-items: center; gap: 0.4rem; color: var(--text-secondary); font-size: 0.9em;">
+                        <input type="checkbox" id="skill-install-force"> reinstall (overwrite if already installed)
+                    </label>
+                    <button id="install-selected-btn" class="config-btn config-btn-primary">Install selected (<span id="install-selected-count">0</span>)</button>
+                </div>
+            `;
+        }
+
+        container.innerHTML = html;
+
+        const checks = container.querySelectorAll<HTMLInputElement>('.skill-discover-check');
+        const countEl = container.querySelector('#install-selected-count');
+        const installBtn = container.querySelector('#install-selected-btn') as HTMLButtonElement | null;
+        const updateCount = () => {
+            if (!countEl) return;
+            countEl.textContent = String(
+                Array.from(checks).filter((c) => c.checked).length,
+            );
+        };
+        checks.forEach((c) => c.addEventListener('change', updateCount));
+        updateCount();
+
+        if (installBtn) {
+            installBtn.addEventListener('click', async () => {
+                const selected = Array.from(checks)
+                    .filter((c) => c.checked)
+                    .map((c) => c.dataset.subpath as string);
+                if (!selected.length) return;
+                const force = (container.querySelector('#skill-install-force') as HTMLInputElement | null)?.checked || false;
+                await this._installSelectedSkills(repo, ref, sha, selected, force, installBtn);
+            });
+        }
+    }
+
+    private async _installSelectedSkills(
+        repo: string,
+        ref: string,
+        sha: string,
+        paths: string[],
+        force: boolean,
+        btn: HTMLButtonElement,
+    ): Promise<void> {
+        btn.disabled = true;
+        btn.textContent = 'Installing…';
+        try {
+            const res = await fetch('/api/skills/install', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    repo,
+                    paths,
+                    // Pin to the same SHA the user just previewed.
+                    ref: sha || ref || undefined,
+                    force,
+                }),
+            });
+            const result = await res.json();
+            if (!res.ok) {
+                alert(result.detail || 'Install failed');
+                return;
+            }
+            const lines = [`Installed ${result.installed.length}`];
+            if (result.skipped.length) lines.push(`Skipped ${result.skipped.length}`);
+            if (result.errors.length) lines.push(`Errors ${result.errors.length}`);
+            alert(lines.join('\n'));
+            await this._loadSkills();
+            await this._loadToolTypes();
+            if (this._selectedAgentId) this._selectAgent(this._selectedAgentId);
+            this._renderPlaceholder();
+        } catch (e) {
+            alert(`Install failed: ${e}`);
+        } finally {
+            btn.disabled = false;
+            btn.textContent = 'Install selected';
+        }
     }
 
     private _showCreateSkillForm(): void {

--- a/src/rhiza_agents/db/sqlite.py
+++ b/src/rhiza_agents/db/sqlite.py
@@ -93,6 +93,8 @@ class Database:
                 description TEXT NOT NULL,
                 source TEXT NOT NULL,
                 source_ref TEXT,
+                source_sha TEXT,
+                source_branch TEXT,
                 skill_md TEXT NOT NULL,
                 scripts_json TEXT,
                 references_json TEXT,
@@ -103,6 +105,15 @@ class Database:
             )
         """)
         await self.database.execute("CREATE INDEX IF NOT EXISTS idx_skills_user_id ON skills(user_id)")
+        # Idempotent migration for installs that predate the source_sha /
+        # source_branch columns. SQLite errors with "duplicate column" when
+        # the column already exists; swallow that one specifically.
+        for column, decl in (("source_sha", "TEXT"), ("source_branch", "TEXT")):
+            try:
+                await self.database.execute(f"ALTER TABLE skills ADD COLUMN {column} {decl}")
+            except Exception as e:
+                if "duplicate column" not in str(e).lower():
+                    raise
 
         # Per-user encrypted credentials. Each row is one named secret value.
         # The value column is the only place secret material lives — name is
@@ -413,6 +424,8 @@ class Database:
         source: str,
         skill_md: str,
         source_ref: str | None = None,
+        source_sha: str | None = None,
+        source_branch: str | None = None,
         scripts_json: str | None = None,
         references_json: str | None = None,
         assets_json: str | None = None,
@@ -420,8 +433,10 @@ class Database:
         """Create a user skill."""
         await self.database.execute(
             """INSERT INTO skills (id, user_id, name, description, source, source_ref,
+                   source_sha, source_branch,
                    skill_md, scripts_json, references_json, assets_json)
                VALUES (:id, :user_id, :name, :description, :source, :source_ref,
+                   :source_sha, :source_branch,
                    :skill_md, :scripts_json, :references_json, :assets_json)""",
             {
                 "id": skill_id,
@@ -430,6 +445,8 @@ class Database:
                 "description": description,
                 "source": source,
                 "source_ref": source_ref,
+                "source_sha": source_sha,
+                "source_branch": source_branch,
                 "skill_md": skill_md,
                 "scripts_json": scripts_json,
                 "references_json": references_json,
@@ -443,8 +460,30 @@ class Database:
             "description": description,
             "source": source,
             "source_ref": source_ref,
+            "source_sha": source_sha,
+            "source_branch": source_branch,
             "enabled": True,
         }
+
+    async def find_user_skill_by_source_ref(self, user_id: str, source_ref: str) -> dict | None:
+        """Look up a user-owned skill that was installed from a specific source_ref.
+
+        Used by the discover endpoint to mark skills as already-installed and by
+        the install endpoint to reject duplicates without --force.
+        """
+        row = await self.database.fetch_one(
+            "SELECT * FROM skills WHERE user_id = :user_id AND source_ref = :source_ref",
+            {"user_id": user_id, "source_ref": source_ref},
+        )
+        return dict(row._mapping) if row else None
+
+    async def list_user_github_skills(self, user_id: str) -> list[dict]:
+        """List the user's skills that were installed from GitHub (refreshable)."""
+        rows = await self.database.fetch_all(
+            "SELECT * FROM skills WHERE user_id = :user_id AND source = 'github'",
+            {"user_id": user_id},
+        )
+        return [dict(row._mapping) for row in rows]
 
     async def update_skill(self, skill_id: str, **fields) -> bool:
         """Update fields on a skill. Returns True if found."""

--- a/src/rhiza_agents/github_skills.py
+++ b/src/rhiza_agents/github_skills.py
@@ -1,0 +1,262 @@
+"""GitHub interactions for the skills install/discover/refresh routes.
+
+Concentrates every HTTP call to GitHub in one module so the routes stay
+focused on persistence/HTTP-glue and the GitHub-shape concerns (refs vs
+SHAs, contents API vs raw, default-branch resolution, optional auth via
+``GITHUB_TOKEN``) live in one place.
+
+Anonymous GitHub API has a 60/hr per-IP rate limit, which bulk install +
+refresh + multi-skill discover blow through fast. Set ``GITHUB_TOKEN`` in
+the environment to raise the quota to 5000/hr.
+
+The functions here are async coroutines that take an injected ``httpx.AsyncClient``
+so the routes can share a connection pool and tests can patch the client
+with a mock.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+
+import httpx
+
+_GITHUB_API = "https://api.github.com"
+_RAW = "https://raw.githubusercontent.com"
+
+
+def _headers() -> dict[str, str]:
+    """Return default headers, including the GITHUB_TOKEN if set.
+
+    Anonymous GitHub API is rate-limited at 60/hr per IP. With a token it's
+    5000/hr — bulk install + refresh easily blow past the anonymous quota,
+    so we honor a ``GITHUB_TOKEN`` env var when present.
+    """
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+@dataclass
+class SkillManifest:
+    """A discovered skill before any install side-effects."""
+
+    subpath: str  # path inside the repo, e.g. "skills/ecmwf-fetch"
+    name: str
+    description: str
+    license: str | None
+    compatibility: str | None
+    has_scripts: bool
+
+
+@dataclass
+class SkillContents:
+    """A fully-fetched skill ready to persist."""
+
+    subpath: str
+    name: str
+    description: str
+    skill_md: str
+    scripts_json: str | None
+    references_json: str | None
+    assets_json: str | None
+
+
+class GitHubError(Exception):
+    """Raised for GitHub-side problems (404, rate limit, etc.) with a user-readable message."""
+
+
+async def resolve_default_branch(client: httpx.AsyncClient, owner: str, repo: str) -> str:
+    """Return the repo's default branch name (e.g. 'main' or 'master')."""
+    resp = await client.get(f"{_GITHUB_API}/repos/{owner}/{repo}", headers=_headers())
+    if resp.status_code == 404:
+        raise GitHubError(f"repo {owner}/{repo} not found")
+    if resp.status_code == 403:
+        raise GitHubError("GitHub rate limit exceeded — set GITHUB_TOKEN to raise the quota")
+    resp.raise_for_status()
+    return resp.json().get("default_branch") or "main"
+
+
+async def resolve_sha(client: httpx.AsyncClient, owner: str, repo: str, ref: str) -> str:
+    """Resolve a branch / tag / partial-sha into a full commit SHA."""
+    resp = await client.get(f"{_GITHUB_API}/repos/{owner}/{repo}/commits/{ref}", headers=_headers())
+    if resp.status_code == 404:
+        raise GitHubError(f"ref {ref!r} not found in {owner}/{repo}")
+    if resp.status_code == 403:
+        raise GitHubError("GitHub rate limit exceeded — set GITHUB_TOKEN to raise the quota")
+    resp.raise_for_status()
+    sha = resp.json().get("sha")
+    if not sha:
+        raise GitHubError(f"GitHub did not return a SHA for {ref!r}")
+    return sha
+
+
+async def fetch_skill_md(client: httpx.AsyncClient, owner: str, repo: str, sha: str, path: str) -> str | None:
+    """Fetch ``<path>/SKILL.md`` at the given SHA. Returns None if absent."""
+    skill_md_path = f"{path}/SKILL.md".lstrip("/") if path else "SKILL.md"
+    url = f"{_RAW}/{owner}/{repo}/{sha}/{skill_md_path}"
+    resp = await client.get(url, headers=_headers())
+    if resp.status_code == 404:
+        return None
+    if resp.status_code == 403:
+        raise GitHubError("GitHub rate limit exceeded — set GITHUB_TOKEN to raise the quota")
+    resp.raise_for_status()
+    return resp.text
+
+
+async def fetch_companion_dir(
+    client: httpx.AsyncClient, owner: str, repo: str, sha: str, dir_path: str
+) -> dict[str, str] | None:
+    """Fetch every file under ``<dir_path>`` at the given SHA, as ``{name: content}``.
+
+    Returns None if the directory doesn't exist. Used for ``scripts/`` and
+    ``references/`` companion dirs.
+    """
+    url = f"{_GITHUB_API}/repos/{owner}/{repo}/contents/{dir_path}?ref={sha}"
+    resp = await client.get(url, headers=_headers())
+    if resp.status_code == 404:
+        return None
+    if resp.status_code == 403:
+        raise GitHubError("GitHub rate limit exceeded — set GITHUB_TOKEN to raise the quota")
+    resp.raise_for_status()
+    files = resp.json()
+    if not isinstance(files, list):
+        return None
+    contents: dict[str, str] = {}
+    for f in files:
+        if f.get("type") != "file":
+            continue
+        download_url = f.get("download_url")
+        if not download_url:
+            continue
+        file_resp = await client.get(download_url, headers=_headers())
+        if file_resp.status_code == 200:
+            contents[f["name"]] = file_resp.text
+    return contents or None
+
+
+async def list_subdir_skills(
+    client: httpx.AsyncClient, owner: str, repo: str, sha: str, path: str
+) -> tuple[list[str], list[tuple[str, str]]]:
+    """List immediate subdirectories of ``<path>`` that contain a SKILL.md.
+
+    Returns ``(skill_subpaths, skipped)`` where ``skill_subpaths`` is a list
+    of full repo paths (e.g. ``"skills/ecmwf-fetch"``) and ``skipped`` is a
+    list of ``(subpath, reason)`` tuples for entries that were not skills.
+
+    Does not recurse — only direct children of ``path``.
+    """
+    list_path = path.lstrip("/") if path else ""
+    url = f"{_GITHUB_API}/repos/{owner}/{repo}/contents/{list_path}?ref={sha}"
+    resp = await client.get(url, headers=_headers())
+    if resp.status_code == 404:
+        raise GitHubError(f"path {path!r} not found in {owner}/{repo}@{sha[:7]}")
+    if resp.status_code == 403:
+        raise GitHubError("GitHub rate limit exceeded — set GITHUB_TOKEN to raise the quota")
+    resp.raise_for_status()
+    entries = resp.json()
+    if not isinstance(entries, list):
+        raise GitHubError(f"path {path!r} is a file, not a directory")
+
+    skill_subpaths: list[str] = []
+    skipped: list[tuple[str, str]] = []
+    for entry in entries:
+        if entry.get("type") != "dir":
+            continue
+        subpath = entry["path"]  # full repo path, e.g. "skills/ecmwf-fetch"
+        skill_md = await fetch_skill_md(client, owner, repo, sha, subpath)
+        if skill_md is None:
+            skipped.append((subpath, "no SKILL.md"))
+            continue
+        skill_subpaths.append(subpath)
+    return skill_subpaths, skipped
+
+
+async def fetch_skill_contents(
+    client: httpx.AsyncClient, owner: str, repo: str, sha: str, subpath: str
+) -> SkillContents:
+    """Fetch a complete skill (SKILL.md + scripts/ + references/) at a SHA.
+
+    Raises ``GitHubError`` if the SKILL.md is missing.
+    """
+    from .agents.tools.skills import parse_skill_md
+
+    skill_md = await fetch_skill_md(client, owner, repo, sha, subpath)
+    if skill_md is None:
+        raise GitHubError(f"no SKILL.md at {subpath!r}")
+    parsed = parse_skill_md(skill_md)
+
+    scripts = await fetch_companion_dir(client, owner, repo, sha, f"{subpath}/scripts")
+    refs = await fetch_companion_dir(client, owner, repo, sha, f"{subpath}/references")
+
+    return SkillContents(
+        subpath=subpath,
+        name=parsed.name,
+        description=parsed.description,
+        skill_md=skill_md,
+        scripts_json=json.dumps(scripts) if scripts else None,
+        references_json=json.dumps(refs) if refs else None,
+        assets_json=None,
+    )
+
+
+async def discover_skills(
+    client: httpx.AsyncClient, owner: str, repo: str, sha: str, path: str
+) -> tuple[list[SkillManifest], list[tuple[str, str]]]:
+    """Discover skills under ``<path>`` at the given SHA. Returns ``(manifests, skipped)``.
+
+    The discover step is intentionally lightweight: it only fetches each
+    candidate's SKILL.md (one HTTP per candidate), not its scripts or
+    references. That keeps preview cheap when the user is just browsing.
+    """
+    from .agents.tools.skills import parse_skill_md
+
+    # Try the direct path first — single-skill mode.
+    direct_md = await fetch_skill_md(client, owner, repo, sha, path)
+    if direct_md is not None:
+        parsed = parse_skill_md(direct_md)
+        scripts = await fetch_companion_dir(
+            client, owner, repo, sha, f"{path.rstrip('/')}/scripts" if path else "scripts"
+        )
+        return (
+            [
+                SkillManifest(
+                    subpath=path or "",
+                    name=parsed.name,
+                    description=parsed.description,
+                    license=parsed.license,
+                    compatibility=parsed.compatibility,
+                    has_scripts=bool(scripts),
+                )
+            ],
+            [],
+        )
+
+    # Otherwise treat ``path`` as a container of skills.
+    subpaths, skipped = await list_subdir_skills(client, owner, repo, sha, path)
+    manifests: list[SkillManifest] = []
+    for sp in subpaths:
+        skill_md = await fetch_skill_md(client, owner, repo, sha, sp)
+        if skill_md is None:
+            skipped.append((sp, "no SKILL.md"))
+            continue
+        try:
+            parsed = parse_skill_md(skill_md)
+        except ValueError as exc:
+            skipped.append((sp, f"invalid SKILL.md: {exc}"))
+            continue
+        scripts = await fetch_companion_dir(client, owner, repo, sha, f"{sp}/scripts")
+        manifests.append(
+            SkillManifest(
+                subpath=sp,
+                name=parsed.name,
+                description=parsed.description,
+                license=parsed.license,
+                compatibility=parsed.compatibility,
+                has_scripts=bool(scripts),
+            )
+        )
+    return manifests, skipped

--- a/src/rhiza_agents/routes/skills.py
+++ b/src/rhiza_agents/routes/skills.py
@@ -1,4 +1,4 @@
-"""Skills CRUD and GitHub install API routes."""
+"""Skills CRUD and GitHub install/discover/refresh API routes."""
 
 import json
 import logging
@@ -11,10 +11,34 @@ from pydantic import BaseModel
 from ..agents.graph import invalidate_graph_cache
 from ..agents.tools.skills import parse_skill_md, requires_sandbox
 from ..deps import get_db, get_user_id, invalidate_skill_cache, require_auth
+from ..github_skills import (
+    GitHubError,
+    SkillContents,
+    discover_skills,
+    fetch_skill_contents,
+    resolve_default_branch,
+    resolve_sha,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["skills"])
+
+
+def _skill_summary(skill: dict) -> dict:
+    """Shared shape for list/get/install/refresh responses."""
+    return {
+        "id": skill["id"],
+        "name": skill["name"],
+        "description": skill["description"],
+        "source": skill["source"],
+        "source_ref": skill.get("source_ref"),
+        "source_sha": skill.get("source_sha"),
+        "source_branch": skill.get("source_branch"),
+        "enabled": bool(skill.get("enabled", True)),
+        "system": skill.get("user_id") is None,
+        "requires_sandbox": requires_sandbox(skill),
+    }
 
 
 @router.get("/api/skills")
@@ -23,19 +47,7 @@ async def list_skills(request: Request, user: dict = Depends(require_auth)):
     db = get_db(request)
     user_id = get_user_id(request)
     skills = await db.list_skills(user_id)
-    return [
-        {
-            "id": s["id"],
-            "name": s["name"],
-            "description": s["description"],
-            "source": s["source"],
-            "source_ref": s.get("source_ref"),
-            "enabled": bool(s.get("enabled", True)),
-            "system": s.get("user_id") is None,
-            "requires_sandbox": requires_sandbox(s),
-        }
-        for s in skills
-    ]
+    return [_skill_summary(s) for s in skills]
 
 
 @router.get("/api/skills/{skill_id}")
@@ -45,19 +57,11 @@ async def get_skill(request: Request, skill_id: str, user: dict = Depends(requir
     skill = await db.get_skill(skill_id)
     if not skill:
         raise HTTPException(status_code=404, detail="Skill not found")
-    return {
-        "id": skill["id"],
-        "name": skill["name"],
-        "description": skill["description"],
-        "source": skill["source"],
-        "source_ref": skill.get("source_ref"),
-        "enabled": bool(skill.get("enabled", True)),
-        "system": skill.get("user_id") is None,
-        "skill_md": skill["skill_md"],
-        "requires_sandbox": requires_sandbox(skill),
-        "scripts": list(json.loads(skill["scripts_json"]).keys()) if skill.get("scripts_json") else [],
-        "references": list(json.loads(skill["references_json"]).keys()) if skill.get("references_json") else [],
-    }
+    out = _skill_summary(skill)
+    out["skill_md"] = skill["skill_md"]
+    out["scripts"] = list(json.loads(skill["scripts_json"]).keys()) if skill.get("scripts_json") else []
+    out["references"] = list(json.loads(skill["references_json"]).keys()) if skill.get("references_json") else []
+    return out
 
 
 class SkillCreate(BaseModel):
@@ -72,7 +76,6 @@ async def create_skill(request: Request, body: SkillCreate, user: dict = Depends
     db = get_db(request)
     user_id = get_user_id(request)
 
-    # Build a valid SKILL.md from the user input
     skill_md = f"""---
 name: {body.name}
 description: {body.description}
@@ -80,7 +83,6 @@ description: {body.description}
 
 {body.prompt}
 """
-    # Validate it parses correctly
     try:
         parse_skill_md(skill_md)
     except ValueError as e:
@@ -100,97 +102,366 @@ description: {body.description}
     return {"id": skill_id, "name": body.name, "description": body.description, "source": "custom"}
 
 
-class SkillInstall(BaseModel):
-    repo: str  # "owner/repo" or "owner/repo/path"
-    path: str | None = None  # Optional subdirectory path
+# --- Discover / install / refresh from GitHub --------------------------
+
+
+def _parse_repo_arg(repo: str) -> tuple[str, str, str]:
+    """Split ``owner/repo`` (optionally ``owner/repo/path``) into its parts.
+
+    The optional inline path lets old single-skill callers continue to work.
+    Newer callers should pass ``path`` explicitly.
+    """
+    parts = repo.split("/", 2)
+    if len(parts) < 2:
+        raise HTTPException(status_code=400, detail="repo must be 'owner/repo' or 'owner/repo/path'")
+    inline_path = parts[2] if len(parts) > 2 else ""
+    return parts[0], parts[1], inline_path
+
+
+async def _resolve_ref_to_sha(client: httpx.AsyncClient, owner: str, repo: str, ref: str | None) -> tuple[str, str]:
+    """Resolve a user-supplied ref (or None for default branch) to ``(branch, sha)``.
+
+    The branch is recorded so refresh re-resolves the same branch HEAD,
+    even after the user has installed and pushed mid-flight.
+    """
+    branch = ref or await resolve_default_branch(client, owner, repo)
+    sha = await resolve_sha(client, owner, repo, branch)
+    return branch, sha
+
+
+class SkillDiscoverBody(BaseModel):
+    repo: str
+    path: str | None = None
+    ref: str | None = None  # branch / tag / sha; default = repo default branch
+
+
+@router.post("/api/skills/discover")
+async def discover_skills_route(request: Request, body: SkillDiscoverBody, user: dict = Depends(require_auth)):
+    """List skills available under a repo path without installing them.
+
+    Returns:
+        {
+          source_sha, source_branch, source_ref,
+          available: [{subpath, name, description, license, compatibility,
+                       has_scripts, already_installed: {id, sha} | None}],
+          skipped: [{subpath, reason}],
+          errors: [...]
+        }
+    """
+    db = get_db(request)
+    user_id = get_user_id(request)
+    owner, repo, inline_path = _parse_repo_arg(body.repo)
+    path = body.path if body.path is not None else inline_path
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        try:
+            branch, sha = await _resolve_ref_to_sha(client, owner, repo, body.ref)
+            manifests, skipped = await discover_skills(client, owner, repo, sha, path)
+        except GitHubError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+    available = []
+    for m in manifests:
+        # Source ref persisted on installed skills uses the same shape as
+        # below — match against it to mark already-installed entries.
+        candidate_ref = f"{owner}/{repo}/{m.subpath}" if m.subpath else f"{owner}/{repo}"
+        existing = await db.find_user_skill_by_source_ref(user_id, candidate_ref)
+        already = None
+        if existing:
+            already = {
+                "id": existing["id"],
+                "sha": existing.get("source_sha"),
+            }
+        available.append(
+            {
+                "subpath": m.subpath,
+                "name": m.name,
+                "description": m.description,
+                "license": m.license,
+                "compatibility": m.compatibility,
+                "has_scripts": m.has_scripts,
+                "already_installed": already,
+            }
+        )
+
+    return {
+        "source_sha": sha,
+        "source_branch": branch,
+        "source_ref": f"{owner}/{repo}",
+        "available": available,
+        "skipped": [{"subpath": sp, "reason": r} for sp, r in skipped],
+        "errors": [],
+    }
+
+
+class SkillInstallBody(BaseModel):
+    repo: str
+    # New shape: explicit list of subpaths chosen from a discover response.
+    paths: list[str] | None = None
+    # Legacy single-skill shape kept for backward compat with non-frontend callers.
+    path: str | None = None
+    ref: str | None = None
+    # When true, re-install a skill the user already has (deletes the old row).
+    force: bool = False
+
+
+async def _persist_install(
+    db,
+    user_id: str,
+    owner: str,
+    repo: str,
+    branch: str,
+    sha: str,
+    contents: SkillContents,
+    *,
+    force: bool,
+) -> tuple[dict | None, str | None]:
+    """Insert a skill row, returning ``(skill_row, error_message)``."""
+    source_ref = f"{owner}/{repo}/{contents.subpath}" if contents.subpath else f"{owner}/{repo}"
+    existing = await db.find_user_skill_by_source_ref(user_id, source_ref)
+    if existing and not force:
+        return None, f"already installed (id={existing['id']})"
+    if existing and force:
+        await db.delete_skill(existing["id"], user_id)
+        invalidate_skill_cache(existing["id"])
+
+    skill_id = f"gh-{uuid.uuid4().hex[:12]}"
+    row = await db.create_skill(
+        skill_id=skill_id,
+        user_id=user_id,
+        name=contents.name,
+        description=contents.description,
+        source="github",
+        source_ref=source_ref,
+        source_sha=sha,
+        source_branch=branch,
+        skill_md=contents.skill_md,
+        scripts_json=contents.scripts_json,
+        references_json=contents.references_json,
+        assets_json=contents.assets_json,
+    )
+    invalidate_skill_cache(skill_id)
+    return row, None
 
 
 @router.post("/api/skills/install")
-async def install_skill(request: Request, body: SkillInstall, user: dict = Depends(require_auth)):
-    """Install a skill from a GitHub repository."""
+async def install_skill(request: Request, body: SkillInstallBody, user: dict = Depends(require_auth)):
+    """Install one or more skills from a GitHub repository at a pinned SHA.
+
+    Accepts either ``paths: [...]`` (preferred — list of skill subpaths
+    relative to the repo) or the legacy ``path: "..."`` (single skill).
+    All paths are installed at the same commit SHA so they're consistent.
+    """
     db = get_db(request)
     user_id = get_user_id(request)
+    owner, repo, inline_path = _parse_repo_arg(body.repo)
 
-    # Parse repo and path
-    parts = body.repo.split("/", 2)
-    if len(parts) < 2:
-        raise HTTPException(status_code=400, detail="repo must be 'owner/repo' or 'owner/repo/path'")
-    owner, repo = parts[0], parts[1]
-    path = body.path or (parts[2] if len(parts) > 2 else "")
+    paths: list[str]
+    if body.paths:
+        paths = list(body.paths)
+    elif body.path is not None:
+        paths = [body.path]
+    elif inline_path:
+        paths = [inline_path]
+    else:
+        # No path given — install the repo root if it has a SKILL.md.
+        paths = [""]
 
-    # Build the raw URL for SKILL.md
-    skill_md_path = f"{path}/SKILL.md" if path else "SKILL.md"
-    raw_url = f"https://raw.githubusercontent.com/{owner}/{repo}/main/{skill_md_path}"
+    installed: list[dict] = []
+    errors: list[dict] = []
+    skipped: list[dict] = []
 
-    async with httpx.AsyncClient(timeout=15) as client:
-        # Fetch SKILL.md
-        resp = await client.get(raw_url)
-        if resp.status_code == 404:
-            raise HTTPException(status_code=404, detail=f"SKILL.md not found at {owner}/{repo}/{skill_md_path}")
-        if resp.status_code == 403:
-            raise HTTPException(status_code=429, detail="GitHub rate limit exceeded, try again later")
-        resp.raise_for_status()
-        skill_md = resp.text
+    async with httpx.AsyncClient(timeout=30) as client:
+        try:
+            branch, sha = await _resolve_ref_to_sha(client, owner, repo, body.ref)
+        except GitHubError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
 
-    # Validate
-    try:
-        parsed = parse_skill_md(skill_md)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid SKILL.md: {e}") from e
-
-    # Fetch companion files via GitHub tree API
-    scripts_json = None
-    references_json = None
-    assets_json = None
-
-    async with httpx.AsyncClient(timeout=15) as client:
-        base_api = f"https://api.github.com/repos/{owner}/{repo}/contents"
-        base_path = path or ""
-
-        for dirname, target in [("scripts", "scripts_json"), ("references", "references_json")]:
-            dir_path = f"{base_path}/{dirname}" if base_path else dirname
-            dir_resp = await client.get(f"{base_api}/{dir_path}")
-            if dir_resp.status_code != 200:
+        for path in paths:
+            try:
+                contents = await fetch_skill_contents(client, owner, repo, sha, path)
+            except GitHubError as e:
+                errors.append({"subpath": path, "error": str(e)})
                 continue
-            files = dir_resp.json()
-            if not isinstance(files, list):
+            except ValueError as e:
+                # Bad SKILL.md
+                errors.append({"subpath": path, "error": f"invalid SKILL.md: {e}"})
                 continue
-            contents = {}
-            for f in files:
-                if f.get("type") != "file":
-                    continue
-                file_resp = await client.get(f["download_url"])
-                if file_resp.status_code == 200:
-                    contents[f["name"]] = file_resp.text
-            if contents:
-                if target == "scripts_json":
-                    scripts_json = json.dumps(contents)
-                elif target == "references_json":
-                    references_json = json.dumps(contents)
 
-    source_ref = f"{owner}/{repo}/{path}" if path else f"{owner}/{repo}"
-    skill_id = f"gh-{uuid.uuid4().hex[:12]}"
-    await db.create_skill(
-        skill_id=skill_id,
-        user_id=user_id,
-        name=parsed.name,
-        description=parsed.description,
-        source="github",
-        source_ref=source_ref,
-        skill_md=skill_md,
-        scripts_json=scripts_json,
-        references_json=references_json,
-        assets_json=assets_json,
-    )
-    invalidate_skill_cache(skill_id)
-    invalidate_graph_cache()
+            row, err = await _persist_install(db, user_id, owner, repo, branch, sha, contents, force=body.force)
+            if err:
+                skipped.append({"subpath": path, "reason": err})
+                continue
+            assert row is not None
+            installed.append(_skill_summary(row))
+
+    if installed:
+        invalidate_graph_cache()
+
     return {
-        "id": skill_id,
-        "name": parsed.name,
-        "description": parsed.description,
-        "source": "github",
-        "source_ref": source_ref,
+        "source_sha": sha,
+        "source_branch": branch,
+        "installed": installed,
+        "skipped": skipped,
+        "errors": errors,
     }
+
+
+# --- Refresh -----------------------------------------------------------
+
+
+def _parse_source_ref(source_ref: str) -> tuple[str, str, str]:
+    """Inverse of the source_ref construction used in _persist_install."""
+    parts = source_ref.split("/", 2)
+    if len(parts) < 2:
+        raise GitHubError(f"malformed source_ref {source_ref!r}")
+    owner, repo = parts[0], parts[1]
+    subpath = parts[2] if len(parts) > 2 else ""
+    return owner, repo, subpath
+
+
+async def _refresh_one(db, client: httpx.AsyncClient, skill: dict) -> dict:
+    """Refresh a single skill from upstream. Returns a result entry.
+
+    Result shape: ``{id, name, status, sha, prev_sha?, error?}`` where
+    ``status`` is one of ``"updated"``, ``"unchanged"``, ``"error"``,
+    or ``"skipped"`` (e.g. for source=custom).
+    """
+    if skill.get("source") != "github" or not skill.get("source_ref"):
+        return {
+            "id": skill["id"],
+            "name": skill["name"],
+            "status": "skipped",
+            "error": "skill is not GitHub-sourced",
+        }
+
+    try:
+        owner, repo, subpath = _parse_source_ref(skill["source_ref"])
+    except GitHubError as e:
+        return {"id": skill["id"], "name": skill["name"], "status": "error", "error": str(e)}
+
+    branch = skill.get("source_branch")
+    try:
+        if not branch:
+            branch = await resolve_default_branch(client, owner, repo)
+        latest_sha = await resolve_sha(client, owner, repo, branch)
+    except GitHubError as e:
+        return {"id": skill["id"], "name": skill["name"], "status": "error", "error": str(e)}
+
+    prev_sha = skill.get("source_sha")
+    if prev_sha and latest_sha == prev_sha:
+        return {
+            "id": skill["id"],
+            "name": skill["name"],
+            "status": "unchanged",
+            "sha": latest_sha,
+        }
+
+    try:
+        contents = await fetch_skill_contents(client, owner, repo, latest_sha, subpath)
+    except (GitHubError, ValueError) as e:
+        return {"id": skill["id"], "name": skill["name"], "status": "error", "error": str(e)}
+
+    # Compare per-file content. Only update if anything actually changed,
+    # so a same-content reinstall (e.g. SHA bumped by an unrelated commit)
+    # doesn't create churn.
+    same = (
+        contents.skill_md == skill.get("skill_md")
+        and contents.scripts_json == skill.get("scripts_json")
+        and contents.references_json == skill.get("references_json")
+        and contents.assets_json == skill.get("assets_json")
+    )
+    if same and prev_sha:
+        # Bump the recorded SHA + branch but report unchanged content.
+        await db.update_skill(skill["id"], source_sha=latest_sha, source_branch=branch)
+        return {
+            "id": skill["id"],
+            "name": skill["name"],
+            "status": "unchanged",
+            "sha": latest_sha,
+            "prev_sha": prev_sha,
+        }
+
+    await db.update_skill(
+        skill["id"],
+        name=contents.name,
+        description=contents.description,
+        skill_md=contents.skill_md,
+        scripts_json=contents.scripts_json,
+        references_json=contents.references_json,
+        assets_json=contents.assets_json,
+        source_sha=latest_sha,
+        source_branch=branch,
+    )
+    invalidate_skill_cache(skill["id"])
+    return {
+        "id": skill["id"],
+        "name": contents.name,
+        "status": "updated",
+        "sha": latest_sha,
+        "prev_sha": prev_sha,
+    }
+
+
+@router.post("/api/skills/{skill_id}/refresh")
+async def refresh_skill(request: Request, skill_id: str, user: dict = Depends(require_auth)):
+    """Re-pull a skill from its source, preserving id and per-skill state."""
+    db = get_db(request)
+    skill = await db.get_skill(skill_id)
+    if not skill:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    if skill.get("user_id") is None:
+        raise HTTPException(status_code=403, detail="Cannot refresh system skills")
+    if skill.get("user_id") != get_user_id(request):
+        raise HTTPException(status_code=403, detail="Not your skill")
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        result = await _refresh_one(db, client, skill)
+
+    if result.get("status") == "updated":
+        invalidate_graph_cache()
+    return result
+
+
+@router.post("/api/skills/refresh")
+async def refresh_all_skills(request: Request, user: dict = Depends(require_auth)):
+    """Refresh every GitHub-sourced skill the user owns.
+
+    Returns ``{updated, unchanged, errors, skipped}``. Each entry is a
+    per-skill result from ``_refresh_one``.
+    """
+    db = get_db(request)
+    user_id = get_user_id(request)
+    skills = await db.list_user_github_skills(user_id)
+
+    updated: list[dict] = []
+    unchanged: list[dict] = []
+    errors: list[dict] = []
+    skipped: list[dict] = []
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        for skill in skills:
+            result = await _refresh_one(db, client, skill)
+            if result["status"] == "updated":
+                updated.append(result)
+            elif result["status"] == "unchanged":
+                unchanged.append(result)
+            elif result["status"] == "skipped":
+                skipped.append(result)
+            else:
+                errors.append(result)
+
+    if updated:
+        invalidate_graph_cache()
+    return {
+        "updated": updated,
+        "unchanged": unchanged,
+        "errors": errors,
+        "skipped": skipped,
+    }
+
+
+# --- Update / delete (unchanged) ---------------------------------------
 
 
 class SkillUpdate(BaseModel):
@@ -220,7 +491,6 @@ async def update_skill(request: Request, skill_id: str, body: SkillUpdate, user:
     if body.description is not None:
         fields["description"] = body.description
 
-    # If prompt changed, rebuild the SKILL.md
     if body.prompt is not None:
         name = body.name or skill["name"]
         description = body.description or skill["description"]

--- a/tests/test_github_skills.py
+++ b/tests/test_github_skills.py
@@ -1,0 +1,346 @@
+"""Tests for github_skills helpers — pure logic with a mocked HTTP client.
+
+Daytona/GitHub aren't touched. Each test stubs ``httpx.AsyncClient`` with
+canned responses keyed off the URL path, then asserts the helper picks the
+right URLs and reads the right fields from the response body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+
+from rhiza_agents.github_skills import (
+    GitHubError,
+    _headers,
+    discover_skills,
+    fetch_companion_dir,
+    fetch_skill_contents,
+    fetch_skill_md,
+    list_subdir_skills,
+    resolve_default_branch,
+    resolve_sha,
+)
+
+
+@dataclass
+class _Resp:
+    status_code: int
+    _json: Any = None
+    text: str = ""
+
+    def json(self) -> Any:
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=None,  # type: ignore[arg-type]
+                response=None,  # type: ignore[arg-type]
+            )
+
+
+class _StubClient:
+    """Stand-in for ``httpx.AsyncClient`` that resolves URLs via a routing dict."""
+
+    def __init__(self, routes: dict[str, _Resp]):
+        self.routes = routes
+        self.calls: list[str] = []
+
+    async def get(self, url: str, headers: dict | None = None) -> _Resp:  # noqa: ARG002
+        self.calls.append(url)
+        if url in self.routes:
+            return self.routes[url]
+        return _Resp(status_code=404)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --- _headers (GITHUB_TOKEN handling) ---------------------------------
+
+
+def test_headers_anonymous_when_token_unset(monkeypatch):
+    """No Authorization header when GITHUB_TOKEN is missing — token is OPTIONAL."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    h = _headers()
+    assert "Authorization" not in h
+    assert h["Accept"] == "application/vnd.github+json"
+
+
+def test_headers_anonymous_when_token_empty(monkeypatch):
+    """Empty / whitespace-only token is treated the same as unset."""
+    monkeypatch.setenv("GITHUB_TOKEN", "   ")
+    h = _headers()
+    assert "Authorization" not in h
+
+
+def test_headers_includes_bearer_when_token_set(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_example")
+    h = _headers()
+    assert h["Authorization"] == "Bearer ghp_example"
+
+
+# --- resolve_default_branch / resolve_sha ------------------------------
+
+
+def test_resolve_default_branch_returns_repo_default():
+    client = _StubClient({"https://api.github.com/repos/o/r": _Resp(200, _json={"default_branch": "develop"})})
+    assert _run(resolve_default_branch(client, "o", "r")) == "develop"
+
+
+def test_resolve_default_branch_falls_back_to_main_when_field_missing():
+    client = _StubClient({"https://api.github.com/repos/o/r": _Resp(200, _json={})})
+    assert _run(resolve_default_branch(client, "o", "r")) == "main"
+
+
+def test_resolve_default_branch_raises_for_404():
+    client = _StubClient({})
+    with pytest.raises(GitHubError, match="not found"):
+        _run(resolve_default_branch(client, "o", "missing"))
+
+
+def test_resolve_default_branch_raises_for_rate_limit():
+    client = _StubClient({"https://api.github.com/repos/o/r": _Resp(403, _json={})})
+    with pytest.raises(GitHubError, match="rate limit"):
+        _run(resolve_default_branch(client, "o", "r"))
+
+
+def test_resolve_sha_returns_full_sha():
+    client = _StubClient(
+        {"https://api.github.com/repos/o/r/commits/main": _Resp(200, _json={"sha": "deadbeefdeadbeefdeadbeef"})}
+    )
+    assert _run(resolve_sha(client, "o", "r", "main")) == "deadbeefdeadbeefdeadbeef"
+
+
+def test_resolve_sha_404():
+    client = _StubClient({})
+    with pytest.raises(GitHubError, match="ref"):
+        _run(resolve_sha(client, "o", "r", "no-such-branch"))
+
+
+# --- fetch_skill_md ---------------------------------------------------
+
+
+def test_fetch_skill_md_at_path_returns_text():
+    sha = "abc123"
+    client = _StubClient(
+        {
+            f"https://raw.githubusercontent.com/o/r/{sha}/skills/x/SKILL.md": _Resp(
+                200, text="---\nname: x\ndescription: t\n---\nbody"
+            )
+        }
+    )
+    out = _run(fetch_skill_md(client, "o", "r", sha, "skills/x"))
+    assert out is not None and "name: x" in out
+
+
+def test_fetch_skill_md_at_root():
+    sha = "abc"
+    client = _StubClient({f"https://raw.githubusercontent.com/o/r/{sha}/SKILL.md": _Resp(200, text="ok")})
+    assert _run(fetch_skill_md(client, "o", "r", sha, "")) == "ok"
+
+
+def test_fetch_skill_md_returns_none_on_404():
+    client = _StubClient({})
+    assert _run(fetch_skill_md(client, "o", "r", "abc", "missing")) is None
+
+
+# --- fetch_companion_dir ----------------------------------------------
+
+
+def test_fetch_companion_dir_collects_files():
+    sha = "abc"
+    base = f"https://api.github.com/repos/o/r/contents/skills/x/scripts?ref={sha}"
+    client = _StubClient(
+        {
+            base: _Resp(
+                200,
+                _json=[
+                    {"type": "file", "name": "fetch.py", "download_url": "raw://fetch"},
+                    {"type": "file", "name": "plot.py", "download_url": "raw://plot"},
+                    {"type": "dir", "name": "subdir"},  # skipped
+                ],
+            ),
+            "raw://fetch": _Resp(200, text="print('fetch')"),
+            "raw://plot": _Resp(200, text="print('plot')"),
+        }
+    )
+    out = _run(fetch_companion_dir(client, "o", "r", sha, "skills/x/scripts"))
+    assert out == {"fetch.py": "print('fetch')", "plot.py": "print('plot')"}
+
+
+def test_fetch_companion_dir_returns_none_when_missing():
+    client = _StubClient({})
+    assert _run(fetch_companion_dir(client, "o", "r", "abc", "skills/x/scripts")) is None
+
+
+# --- list_subdir_skills -----------------------------------------------
+
+
+def test_list_subdir_skills_includes_only_dirs_with_skill_md():
+    sha = "abc"
+    contents_url = f"https://api.github.com/repos/o/r/contents/skills?ref={sha}"
+    client = _StubClient(
+        {
+            contents_url: _Resp(
+                200,
+                _json=[
+                    {"type": "dir", "name": "ecmwf-fetch", "path": "skills/ecmwf-fetch"},
+                    {"type": "dir", "name": "shared", "path": "skills/shared"},
+                    {"type": "file", "name": "README.md", "path": "skills/README.md"},
+                ],
+            ),
+            f"https://raw.githubusercontent.com/o/r/{sha}/skills/ecmwf-fetch/SKILL.md": _Resp(200, text="ok"),
+            # 'shared' has no SKILL.md (default 404) — should be skipped.
+        }
+    )
+    skill_subpaths, skipped = _run(list_subdir_skills(client, "o", "r", sha, "skills"))
+    assert skill_subpaths == ["skills/ecmwf-fetch"]
+    assert skipped == [("skills/shared", "no SKILL.md")]
+
+
+def test_list_subdir_skills_does_not_recurse():
+    """We only check direct children, not nested subdirs."""
+    sha = "abc"
+    contents_url = f"https://api.github.com/repos/o/r/contents/skills?ref={sha}"
+    client = _StubClient(
+        {
+            contents_url: _Resp(
+                200,
+                _json=[{"type": "dir", "name": "fetchers", "path": "skills/fetchers"}],
+            ),
+        }
+    )
+    skill_subpaths, skipped = _run(list_subdir_skills(client, "o", "r", sha, "skills"))
+    assert skill_subpaths == []
+    assert skipped == [("skills/fetchers", "no SKILL.md")]
+    # We probe each direct child's SKILL.md (allowed) but never descend deeper:
+    # any URL that contains '/skills/fetchers/' but isn't the SKILL.md probe
+    # itself would be a nested fetch.
+    deep_paths = [
+        url for url in client.calls if "/skills/fetchers/" in url and not url.endswith("/skills/fetchers/SKILL.md")
+    ]
+    assert deep_paths == []
+
+
+def test_list_subdir_skills_404_path_raises():
+    client = _StubClient({})
+    with pytest.raises(GitHubError, match="not found"):
+        _run(list_subdir_skills(client, "o", "r", "abc", "skills"))
+
+
+# --- discover_skills (single + directory paths) ------------------------
+
+
+def test_discover_single_skill_path():
+    sha = "abc"
+    client = _StubClient(
+        {
+            f"https://raw.githubusercontent.com/o/r/{sha}/skills/x/SKILL.md": _Resp(
+                200,
+                text="---\nname: x\ndescription: A demo skill.\nlicense: MIT\n---\nbody",
+            ),
+        }
+    )
+    manifests, skipped = _run(discover_skills(client, "o", "r", sha, "skills/x"))
+    assert len(manifests) == 1
+    assert manifests[0].name == "x"
+    assert manifests[0].license == "MIT"
+    assert manifests[0].has_scripts is False
+    assert skipped == []
+
+
+def test_discover_directory_of_skills():
+    sha = "abc"
+    contents_url = f"https://api.github.com/repos/o/r/contents/skills?ref={sha}"
+    client = _StubClient(
+        {
+            contents_url: _Resp(
+                200,
+                _json=[
+                    {"type": "dir", "name": "a", "path": "skills/a"},
+                    {"type": "dir", "name": "b", "path": "skills/b"},
+                    {"type": "dir", "name": "noskill", "path": "skills/noskill"},
+                ],
+            ),
+            f"https://raw.githubusercontent.com/o/r/{sha}/skills/a/SKILL.md": _Resp(
+                200, text="---\nname: a\ndescription: A.\n---\n"
+            ),
+            f"https://raw.githubusercontent.com/o/r/{sha}/skills/b/SKILL.md": _Resp(
+                200, text="---\nname: b\ndescription: B.\n---\n"
+            ),
+            # 'a' ships scripts; 'b' doesn't.
+            f"https://api.github.com/repos/o/r/contents/skills/a/scripts?ref={sha}": _Resp(
+                200,
+                _json=[{"type": "file", "name": "f.py", "download_url": "raw://f"}],
+            ),
+            "raw://f": _Resp(200, text="x = 1"),
+        }
+    )
+    manifests, skipped = _run(discover_skills(client, "o", "r", sha, "skills"))
+    names = sorted(m.name for m in manifests)
+    assert names == ["a", "b"]
+    a = next(m for m in manifests if m.name == "a")
+    b = next(m for m in manifests if m.name == "b")
+    assert a.has_scripts is True
+    assert b.has_scripts is False
+    assert ("skills/noskill", "no SKILL.md") in skipped
+
+
+def test_discover_skips_invalid_skill_md():
+    sha = "abc"
+    contents_url = f"https://api.github.com/repos/o/r/contents/skills?ref={sha}"
+    client = _StubClient(
+        {
+            contents_url: _Resp(
+                200,
+                _json=[{"type": "dir", "name": "bad", "path": "skills/bad"}],
+            ),
+            f"https://raw.githubusercontent.com/o/r/{sha}/skills/bad/SKILL.md": _Resp(
+                200, text="not actually a SKILL.md (no frontmatter)"
+            ),
+        }
+    )
+    manifests, skipped = _run(discover_skills(client, "o", "r", sha, "skills"))
+    assert manifests == []
+    assert len(skipped) == 1
+    assert skipped[0][0] == "skills/bad"
+    assert "invalid SKILL.md" in skipped[0][1]
+
+
+# --- fetch_skill_contents (used by install + refresh) -----------------
+
+
+def test_fetch_skill_contents_bundles_skill_md_scripts_refs():
+    sha = "abc"
+    client = _StubClient(
+        {
+            f"https://raw.githubusercontent.com/o/r/{sha}/skills/x/SKILL.md": _Resp(
+                200, text="---\nname: x\ndescription: T.\n---\nbody"
+            ),
+            f"https://api.github.com/repos/o/r/contents/skills/x/scripts?ref={sha}": _Resp(
+                200,
+                _json=[{"type": "file", "name": "f.py", "download_url": "raw://f"}],
+            ),
+            "raw://f": _Resp(200, text="x = 1"),
+            # No references/ — should land as None.
+        }
+    )
+    contents = _run(fetch_skill_contents(client, "o", "r", sha, "skills/x"))
+    assert contents.name == "x"
+    assert contents.description == "T."
+    assert contents.scripts_json is not None and "f.py" in contents.scripts_json
+    assert contents.references_json is None
+
+
+def test_fetch_skill_contents_raises_when_skill_md_missing():
+    client = _StubClient({})
+    with pytest.raises(GitHubError, match="no SKILL.md"):
+        _run(fetch_skill_contents(client, "o", "r", "abc", "skills/missing"))


### PR DESCRIPTION
## Summary

Rework the skills install flow so users can preview all skills in a repo directory, pick a subset, and refresh installed skills from upstream later. Every installed skill now records the commit SHA it came from, so "has this changed upstream?" is a cheap compare.

Motivation: our `rhiza-research/forecasting-skills` repo has 11 skills under `skills/` and the old install UI required one form submission per skill.

## What's new

### Backend routes (all under `/api/skills`)

- `POST /discover` — preview-only. Lists skills under `{repo, path, ref?}` at the resolved commit SHA. Each entry carries `subpath / name / description / license / compatibility / has_scripts / already_installed`. Never installs anything. Lets the UI show the user what would be installed before they commit.
- `POST /install` — accepts `paths: [...]` (list of subpaths chosen from `/discover`) or the legacy single `path` for backward compat. Re-resolves the ref to a SHA at install time so every selected skill pins to the same commit. Returns `{installed, skipped, errors}`; duplicates are skipped unless `force: true`.
- `POST /{skill_id}/refresh` — re-pulls from the stored `source_branch`, diffs per-file content, no-ops when nothing changed (just bumps the recorded SHA), preserves id / enabled / user_id / agent assignments on update.
- `POST /refresh` — bulk variant over every GitHub-sourced skill the user owns.

### Storage

Adds `source_sha` + `source_branch` columns to the skills table with an idempotent `ALTER TABLE` migration that catches "duplicate column" on re-run. Existing rows get `NULL` — the first refresh pins them.

### GitHub integration (`src/rhiza_agents/github_skills.py`)

Concentrates every server-side GitHub call. Functions take an injected `httpx.AsyncClient` so the routes can share a pool and tests can mock with a URL-routing stub. `GITHUB_TOKEN` is optional — anonymous works at 60/hr per IP, the token raises to 5000/hr. 403 responses surface a clear error message pointing at the token.

### Frontend (`frontend/src/widgets/config.ts`)

- Install form: Search button instead of direct Install. Result list shows a checklist (all checked by default) with name, description, `has scripts` chip, `already installed at <sha>` marker. `reinstall (overwrite)` checkbox to opt into force.
- Per-skill row: 7-char SHA chip next to the source label + `⟳` button to refresh that one skill.
- Sidebar: `⟳ Refresh All` button next to `+ Add Skill` for the bulk path.

### Deployment glue

- `docker-compose.yml` passes `GITHUB_TOKEN` through (default empty — keeps it optional).
- `chart/values.yaml` comment now lists `GITHUB_TOKEN` as an optional secret key. The chart already does `envFrom: secretRef`, so adding the key to the Terraform-managed secret (**separate infrastructure PR**) is sufficient — no chart template change needed.

## Test plan

- [x] 17 new unit tests (89 total), all passing:
    - `_headers` token contract: anonymous when unset, anonymous when whitespace, Bearer when set — locks in that the token is **optional**.
    - `resolve_default_branch` / `resolve_sha`: happy path, 404, rate limit.
    - `fetch_skill_md` / `fetch_companion_dir` across 200/404.
    - `list_subdir_skills`: filters files/non-SKILL dirs, does not recurse, raises on 404 root.
    - `discover_skills`: single-path mode, directory-of-skills mode, skips malformed SKILL.md without raising.
    - `fetch_skill_contents` bundles SKILL.md + scripts/ + references/.
- [x] `ruff check` + `ruff format` clean on src/ and tests/.
- [x] Local smoke test: `podman compose up --build`, installed all 11 skills from `rhiza-research/forecasting-skills` via the Search → Install selected flow, confirmed per-skill and bulk refresh.
- [ ] Production deploy needs a follow-up in `infrastructure/` to add `GITHUB_TOKEN` to `kubernetes_secret.rhiza_agents_secrets` (optional — the server works anonymously too, just with a 60/hr GitHub quota).

## Notes

The install endpoint's response shape changed from a single `{id, name, …}` object to `{installed: [...], skipped: [...], errors: [...]}`. The only caller is our own frontend which this PR also updates. Any external scripts posting to `/api/skills/install` would need updating.

Relates to spec [#3 Agent Skills](https://github.com/rhiza-research/rhiza-agents/issues/3).
