### PR TITLE
feat: declare skill credentials via openclaw frontmatter and prompt user when missing

### DIFF
--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -46,10 +46,35 @@ const filesWidget: FilesWidget = new FilesWidget({
     },
 });
 
+const configWidget = new ConfigWidget();
+
 const chatWidget: ChatWidget = new ChatWidget({
     conversationId: appData.conversationId || '',
     activityWidget,
     filesWidget,
+    // Approval cards that are gated on missing credentials use this hook
+    // to pop the Config panel and pre-fill the new-credential form.
+    // Replicates the "view:config" command's re-add logic so the tab shows
+    // up whether or not the user had previously closed it.
+    onOpenCredentialForm: (name: string) => {
+        if (!configWidget.parent) {
+            // Restore the initial layout so configWidget lands back in its
+            // home tab area, then re-hide anything the user had closed
+            // except configWidget itself. Same pattern as addViewCommand.
+            const wasHidden = new Set<Widget>();
+            for (const w of [conversationsWidget, chatWidget, activityWidget, filesWidget, configWidget]) {
+                if (!w.parent && w !== configWidget) {
+                    wasHidden.add(w);
+                }
+            }
+            dock.restoreLayout(initialLayout);
+            for (const w of wasHidden) {
+                w.parent = null;
+            }
+        }
+        dock.activateWidget(configWidget);
+        configWidget.focusCredentials(name);
+    },
 });
 
 const conversationsWidget = new ConversationListWidget({
@@ -57,8 +82,6 @@ const conversationsWidget = new ConversationListWidget({
     currentConversationId: appData.conversationId || '',
     userName: appData.userName || '',
 });
-
-const configWidget = new ConfigWidget();
 
 
 // --- Status Bar ---

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -252,6 +252,13 @@ body { height: 100vh; margin: 0; }
 .config-btn-primary { background: var(--jp-brand-color1); color: white; border: none; }
 .config-btn-danger { color: var(--jp-ui-font-color3); }
 .config-btn-danger:hover { border-color: var(--jp-error-color1); color: var(--jp-error-color1); }
+.config-btn-warning {
+    color: var(--jp-warn-color1, #d4900a);
+    border-color: var(--jp-warn-color1, #d4900a);
+}
+.config-btn-warning:hover {
+    background: var(--jp-warn-color1, #d4900a); color: white;
+}
 .config-btn-sm { padding: 0.2rem 0.5rem; border: 1px solid var(--jp-border-color1); border-radius: 3px; background: none; cursor: pointer; font-size: 0.75rem; color: var(--jp-ui-font-color2); }
 .config-btn-sm:hover { border-color: var(--jp-brand-color1); color: var(--jp-brand-color1); }
 .form-group { margin-bottom: 1rem; }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -187,7 +187,23 @@ body { height: 100vh; margin: 0; }
 .interrupt-args pre { background: var(--jp-layout-color3); padding: 0.5rem; border-radius: 4px; font-size: 0.8rem; color: var(--jp-content-font-color2); }
 .interrupt-actions { display: flex; gap: 0.5rem; padding: 0.5rem; }
 .interrupt-approve { background: var(--jp-accent-color1); color: white; border: none; padding: 0.4rem 1rem; border-radius: 4px; cursor: pointer; }
+.interrupt-approve:disabled { opacity: 0.5; cursor: not-allowed; }
 .interrupt-reject { background: transparent; color: var(--jp-error-color1); border: 1px solid var(--jp-error-color1); padding: 0.4rem 1rem; border-radius: 4px; cursor: pointer; }
+.interrupt-credentials { padding: 0.5rem; }
+.interrupt-credentials-header { font-size: 0.85rem; color: var(--jp-ui-font-color2); margin-bottom: 0.25rem; }
+.interrupt-credentials ul { margin: 0; padding-left: 1.25rem; }
+.interrupt-credentials code { font-size: 0.85rem; }
+.interrupt-cred-missing { color: var(--jp-error-color1); font-weight: 600; }
+.interrupt-missing-banner {
+    display: flex; align-items: center; gap: 0.5rem; justify-content: space-between;
+    margin: 0 0.5rem 0.5rem; padding: 0.4rem 0.6rem; border-radius: 4px;
+    background: rgba(255, 152, 0, 0.1); color: var(--md-orange-300); font-size: 0.85rem;
+}
+.interrupt-set-creds {
+    background: transparent; color: var(--md-orange-300); border: 1px solid var(--md-orange-500);
+    padding: 0.25rem 0.7rem; border-radius: 4px; cursor: pointer; font-size: 0.8rem; white-space: nowrap;
+}
+.interrupt-set-creds:hover { background: rgba(255, 152, 0, 0.2); }
 
 /* Welcome */
 .welcome { text-align: center; padding: 4rem 2rem; color: var(--jp-ui-font-color3); }
@@ -255,6 +271,10 @@ body { height: 100vh; margin: 0; }
 .coming-soon { font-size: 0.7rem; color: var(--jp-ui-font-color3); background: var(--jp-layout-color2); padding: 0.1rem 0.4rem; border-radius: 3px; }
 .vectorstore-list { display: flex; flex-direction: column; gap: 2px; }
 .vs-list-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem; background: var(--jp-layout-color2); border-radius: 4px; font-size: 0.85rem; }
+
+/* Install-preview chip showing a skill's declared env credentials */
+.skill-required-env { color: var(--text-secondary); font-size: 0.85em; }
+.skill-required-env-missing { color: var(--md-orange-300); font-weight: 600; }
 .vs-list-info { display: flex; flex-direction: column; min-width: 0; }
 .vs-list-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--jp-ui-font-color1); }
 .vs-list-count { font-size: 0.7rem; color: var(--jp-ui-font-color3); }

--- a/frontend/src/widgets/chat.ts
+++ b/frontend/src/widgets/chat.ts
@@ -8,6 +8,11 @@ interface ChatWidgetOptions {
     conversationId: string;
     activityWidget: ActivityWidget;
     filesWidget: FilesWidget;
+    /** Open the config panel and surface a new-credential form with the given
+     *  name pre-filled. Wired from app.ts to ConfigWidget.focusCredentials.
+     *  Called when the user clicks "Set credentials" on an approval card that
+     *  is blocked by missing credentials. */
+    onOpenCredentialForm?: (name: string) => void;
 }
 
 /**
@@ -17,6 +22,7 @@ export class ChatWidget extends Widget {
     private _conversationId: string;
     private _activity: ActivityWidget;
     private _files: FilesWidget;
+    private _onOpenCredentialForm?: (name: string) => void;
     private _streamedContent = '';
     private _activeAbortController: AbortController | null = null;
     private _reviewMode = false;
@@ -28,6 +34,10 @@ export class ChatWidget extends Widget {
     private _input!: HTMLTextAreaElement;
     private _sendBtn!: HTMLButtonElement;
     private _execToggle!: HTMLInputElement;
+    /** Handler for the global ``credential-added`` DOM event. Kept as a
+     *  field so we can detach it in `dispose()` if the widget is ever torn
+     *  down (defensive — the ChatWidget lives for the whole session today). */
+    private _credentialAddedHandler: (e: Event) => void;
 
     constructor(options: ChatWidgetOptions) {
         super();
@@ -39,6 +49,7 @@ export class ChatWidget extends Widget {
         this._conversationId = options.conversationId;
         this._activity = options.activityWidget;
         this._files = options.filesWidget;
+        this._onOpenCredentialForm = options.onOpenCredentialForm;
 
         if (localStorage.getItem('execReviewMode') === 'true') {
             this._reviewMode = true;
@@ -46,6 +57,18 @@ export class ChatWidget extends Widget {
 
         this._buildDOM();
         this._loadMessages();
+
+        // When the user saves a new credential elsewhere in the app, the
+        // config widget emits ``credential-added`` on ``document``. Any
+        // currently-rendered approval card that was blocked on that name
+        // can then un-block itself in-place — no stream round-trip needed
+        // because ``_enrich_interrupt_payload`` re-runs on the next resume.
+        this._credentialAddedHandler = (e: Event) => {
+            const detail = (e as CustomEvent).detail;
+            if (!detail || typeof detail.name !== 'string') return;
+            this._onCredentialAdded(detail.name);
+        };
+        document.addEventListener('credential-added', this._credentialAddedHandler);
     }
 
     get conversationId(): string { return this._conversationId; }
@@ -423,10 +446,32 @@ export class ChatWidget extends Widget {
         // every secret name they reference, so the user can see exactly
         // which credentials this run will access before approving.
         const accessedNames = this._collectCredentialNames(toolArgs.credentials);
+        // Server-enriched list of referenced names that are NOT currently in
+        // the user's credential store. Populated by
+        // ``_enrich_interrupt_payload`` on the backend. Empty (or absent on
+        // older sessions) means nothing is blocking.
+        const missingSet = new Set<string>(
+            Array.isArray(interruptData.missing_credentials) ? interruptData.missing_credentials : []
+        );
+
+        const credentialsListHtml = accessedNames
+            .map(n => {
+                const cls = missingSet.has(n) ? 'interrupt-cred-missing' : '';
+                const marker = missingSet.has(n) ? '⚠ ' : '';
+                return `<li data-cred-name="${this._escapeHtml(n)}"><code class="${cls}">${marker}${this._escapeHtml(n)}</code></li>`;
+            })
+            .join('');
         const credentialsBlock = accessedNames.length > 0
             ? `<div class="interrupt-credentials">
                    <div class="interrupt-credentials-header">This run will access:</div>
-                   <ul>${accessedNames.map(n => `<li><code>${this._escapeHtml(n)}</code></li>`).join('')}</ul>
+                   <ul>${credentialsListHtml}</ul>
+               </div>`
+            : '';
+
+        const missingBanner = missingSet.size > 0
+            ? `<div class="interrupt-missing-banner">
+                   <span>${missingSet.size === 1 ? 'This credential is not set' : 'These credentials are not set'} — approve is disabled until they are added.</span>
+                   <button class="interrupt-set-creds">Set credentials</button>
                </div>`
             : '';
 
@@ -434,17 +479,24 @@ export class ChatWidget extends Widget {
             <div class="interrupt-header">Approval Required</div>
             <div class="interrupt-tool">${toolName}</div>
             ${credentialsBlock}
+            ${missingBanner}
             <details class="interrupt-args">
                 <summary>arguments</summary>
                 <pre>${JSON.stringify(toolArgs, null, 2)}</pre>
             </details>
             <div class="interrupt-actions">
-                <button class="interrupt-approve">Approve</button>
+                <button class="interrupt-approve"${missingSet.size > 0 ? ' disabled' : ''}>Approve</button>
                 <button class="interrupt-reject">Reject</button>
             </div>
         `;
 
-        card.querySelector('.interrupt-approve')!.addEventListener('click', () => {
+        // Stash the missing set on the card so the credential-added event
+        // handler can find it and mutate the card in place.
+        (card as any)._missingCredentials = new Set(missingSet);
+
+        const approveBtn = card.querySelector<HTMLButtonElement>('.interrupt-approve')!;
+        approveBtn.addEventListener('click', () => {
+            if (approveBtn.disabled) return;
             card.remove();
             this._resumeExecution('approve', null);
         });
@@ -453,8 +505,50 @@ export class ChatWidget extends Widget {
             this._resumeExecution('reject', 'Rejected by user');
         });
 
+        const setCredsBtn = card.querySelector<HTMLButtonElement>('.interrupt-set-creds');
+        if (setCredsBtn) {
+            setCredsBtn.addEventListener('click', () => {
+                // Open the config panel to the first missing credential.
+                // Each subsequent add (via the credential-added event) walks
+                // the card's missing set down until approve re-enables.
+                const first = Array.from(missingSet)[0];
+                if (first && this._onOpenCredentialForm) {
+                    this._onOpenCredentialForm(first);
+                }
+            });
+        }
+
         this._messagesDiv.appendChild(card);
         this._messagesDiv.scrollTop = this._messagesDiv.scrollHeight;
+    }
+
+    /** Called when ``credential-added`` fires. Walks every interrupt card
+     *  currently in the message area and, for each one that was gated on
+     *  ``name``, removes the pill's missing marker. When the card's missing
+     *  set empties, the Approve button re-enables and the banner hides.
+     *
+     *  The actual DB state is already up to date (the POST happens in the
+     *  config widget's save handler), so re-approving goes through the
+     *  existing ``_resolve_secrets`` check without any new state to sync.
+     */
+    private _onCredentialAdded(name: string): void {
+        const cards = this._messagesDiv.querySelectorAll<HTMLElement>('.interrupt-card');
+        cards.forEach(card => {
+            const missingSet: Set<string> | undefined = (card as any)._missingCredentials;
+            if (!missingSet || !missingSet.has(name)) return;
+            missingSet.delete(name);
+            const pill = card.querySelector<HTMLElement>(`li[data-cred-name="${CSS.escape(name)}"] code`);
+            if (pill) {
+                pill.classList.remove('interrupt-cred-missing');
+                pill.textContent = name;  // drop the ⚠ prefix
+            }
+            if (missingSet.size === 0) {
+                const banner = card.querySelector<HTMLElement>('.interrupt-missing-banner');
+                if (banner) banner.remove();
+                const approve = card.querySelector<HTMLButtonElement>('.interrupt-approve');
+                if (approve) approve.disabled = false;
+            }
+        });
     }
 
     private async _resumeExecution(decision: string, message: string | null): Promise<void> {

--- a/frontend/src/widgets/config.ts
+++ b/frontend/src/widgets/config.ts
@@ -766,6 +766,11 @@ export class ConfigWidget extends Widget {
         `;
 
         if (available.length) {
+            // Snapshot the user's current credential names so we can flag
+            // missing ones on each discovered skill. Uses the list already
+            // loaded on startup; if the user added a credential in this
+            // session the next _loadCredentials call would refresh it.
+            const haveCreds = new Set(this._credentials.map(c => c.name));
             html += '<div style="display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;">';
             for (const skill of available) {
                 const installed = skill.already_installed;
@@ -775,6 +780,16 @@ export class ConfigWidget extends Widget {
                     ? (sameSha
                         ? `<span style="color: var(--text-secondary); font-size: 0.85em;">already installed at ${escapeHtml(sha.slice(0, 7))}</span>`
                         : `<span style="color: var(--text-secondary); font-size: 0.85em;">installed at ${escapeHtml((installed.sha || '?').slice(0, 7))}, ${escapeHtml(sha.slice(0, 7))} available</span>`)
+                    : '';
+                // Openclaw-style env requirements. Highlight names the user
+                // hasn't set yet so the warning is visible before install
+                // rather than only at first run.
+                const requiredEnv: string[] = Array.isArray(skill.required_env) ? skill.required_env : [];
+                const missingEnv = requiredEnv.filter(n => !haveCreds.has(n));
+                const envChip = requiredEnv.length
+                    ? (missingEnv.length
+                        ? `<span class="skill-required-env skill-required-env-missing" title="Missing credentials: ${escapeAttr(missingEnv.join(', '))}"> · ⚠ requires: ${escapeHtml(requiredEnv.join(', '))}</span>`
+                        : `<span class="skill-required-env"> · requires: ${escapeHtml(requiredEnv.join(', '))}</span>`)
                     : '';
                 html += `
                     <label style="display: flex; gap: 0.5rem; align-items: flex-start; cursor: pointer;">
@@ -786,6 +801,7 @@ export class ConfigWidget extends Widget {
                         <span>
                             <strong>${escapeHtml(skill.name)}</strong>
                             ${skill.has_scripts ? '<span style="color: var(--text-secondary); font-size: 0.85em;"> · has scripts</span>' : ''}
+                            ${envChip}
                             ${tag}
                             <br>
                             <span style="color: var(--text-secondary); font-size: 0.9em;">${escapeHtml(skill.description)}</span>
@@ -1119,11 +1135,12 @@ export class ConfigWidget extends Widget {
         }
     }
 
-    private _showNewCredentialForm(): void {
+    private _showNewCredentialForm(prefillName?: string): void {
         if (this._credentialsDisabled) {
             alert('Credentials feature is disabled. Set CREDENTIAL_ENCRYPTION_KEY to enable.');
             return;
         }
+        const nameValueAttr = prefillName ? ` value="${escapeAttr(prefillName)}"` : '';
         this._detail.innerHTML = `
             <div class="config-form">
                 <h2>Add Credential</h2>
@@ -1132,7 +1149,7 @@ export class ConfigWidget extends Widget {
                 </p>
                 <div class="form-group">
                     <label for="cred-name">Name</label>
-                    <input type="text" id="cred-name" placeholder="e.g. NASA_USERNAME">
+                    <input type="text" id="cred-name" placeholder="e.g. NASA_USERNAME"${nameValueAttr}>
                 </div>
                 <div class="form-group">
                     <label for="cred-value">Value</label>
@@ -1144,6 +1161,12 @@ export class ConfigWidget extends Widget {
                 </div>
             </div>
         `;
+        // When pre-filled from an approval card the user only needs to type
+        // the value, so land focus there directly. For a fresh Add-Credential
+        // click we leave focus on the name field (the browser default).
+        if (prefillName) {
+            (this._detail.querySelector('#cred-value') as HTMLInputElement).focus();
+        }
         this._detail.querySelector('#cancel-cred-btn')!.addEventListener('click', () => this._renderPlaceholder());
         this._detail.querySelector('#save-cred-btn')!.addEventListener('click', async () => {
             const name = (this._detail.querySelector('#cred-name') as HTMLInputElement).value.trim();
@@ -1161,7 +1184,25 @@ export class ConfigWidget extends Widget {
             }
             await this._loadCredentials();
             this._renderPlaceholder();
+            // Notify any open approval card that this name is now set. The
+            // chat widget listens for this on ``document`` and unblocks in
+            // place. Emitted after the list reload so any UI that queries
+            // ``/api/credentials`` also sees the new row.
+            document.dispatchEvent(new CustomEvent('credential-added', { detail: { name } }));
         });
+    }
+
+    /** Bring the credentials section into focus and optionally open the
+     *  new-credential form pre-filled with ``name``.
+     *
+     *  app.ts handles the dock-level "activate the Config tab" step via the
+     *  view:config command; this method just renders the correct form. The
+     *  two concerns are kept separate so ConfigWidget doesn't need to know
+     *  about the DockPanel or command registry.
+     */
+    focusCredentials(name?: string): void {
+        this._credentialList.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        this._showNewCredentialForm(name);
     }
 
     private _showEditCredentialForm(cred: any): void {

--- a/frontend/src/widgets/config.ts
+++ b/frontend/src/widgets/config.ts
@@ -550,6 +550,22 @@ export class ConfigWidget extends Widget {
             const actions = document.createElement('div');
             actions.className = 'vs-list-actions';
 
+            // ⚠ surfaces declared-but-not-configured credentials so the user
+            // resolves them BEFORE invoking the skill, not after a HITL card
+            // blocks them. Click opens the config panel pre-filled with all
+            // missing names so the user fills them in one form.
+            const missing: string[] = Array.isArray(skill.missing_credentials)
+                ? skill.missing_credentials
+                : [];
+            if (missing.length > 0) {
+                const warnBtn = document.createElement('button');
+                warnBtn.className = 'config-btn-sm config-btn-warning';
+                warnBtn.textContent = '⚠';
+                warnBtn.title = `Missing credential${missing.length === 1 ? '' : 's'}: ${missing.join(', ')}`;
+                warnBtn.addEventListener('click', () => this.focusCredentials(missing));
+                actions.appendChild(warnBtn);
+            }
+
             const viewBtn = document.createElement('button');
             viewBtn.className = 'config-btn-sm';
             viewBtn.textContent = 'View';
@@ -1192,17 +1208,157 @@ export class ConfigWidget extends Widget {
         });
     }
 
-    /** Bring the credentials section into focus and optionally open the
-     *  new-credential form pre-filled with ``name``.
+    /** Bring the credentials section into focus and open the right add-form.
+     *
+     *  Accepts:
+     *  - nothing: opens an empty new-credential form (used by the "+ Add"
+     *    button).
+     *  - a string: opens the single-input form pre-filled with that name
+     *    (used by the HITL approval card's per-name "Set credentials" button).
+     *  - a string[]: opens a multi-input form with one row per name, all
+     *    saved together (used by the skill-row ⚠ chip).
      *
      *  app.ts handles the dock-level "activate the Config tab" step via the
      *  view:config command; this method just renders the correct form. The
      *  two concerns are kept separate so ConfigWidget doesn't need to know
      *  about the DockPanel or command registry.
      */
-    focusCredentials(name?: string): void {
+    focusCredentials(name?: string | string[]): void {
         this._credentialList.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        this._showNewCredentialForm(name);
+        if (Array.isArray(name)) {
+            const cleaned = name.filter((n) => typeof n === 'string' && n);
+            if (cleaned.length === 0) {
+                this._showNewCredentialForm();
+            } else if (cleaned.length === 1) {
+                this._showNewCredentialForm(cleaned[0]);
+            } else {
+                this._showMissingCredentialsForm(cleaned);
+            }
+        } else {
+            this._showNewCredentialForm(name);
+        }
+    }
+
+    /** Render a multi-input form for entering several missing credentials at once.
+     *
+     *  One row per requested name, each with a value input. "Save all" issues
+     *  parallel POSTs to ``/api/credentials`` and reports per-name results
+     *  inline. Successful saves emit ``credential-added`` events so any open
+     *  HITL approval card un-gates in place. Names that already exist in the
+     *  store are still saved (treated as updates) — easier than fetching
+     *  current state to filter, and matches the user intent of "I just want
+     *  these set".
+     */
+    private _showMissingCredentialsForm(names: string[]): void {
+        if (this._credentialsDisabled) {
+            alert('Credentials feature is disabled. Set CREDENTIAL_ENCRYPTION_KEY to enable.');
+            return;
+        }
+        const rows = names
+            .map(
+                (n) => `
+            <div class="form-group" data-cred-name="${escapeAttr(n)}">
+                <label>${escapeHtml(n)}</label>
+                <input type="password" class="missing-cred-value" data-name="${escapeAttr(n)}">
+                <span class="missing-cred-status" style="font-size: 0.85em; color: var(--text-secondary);"></span>
+            </div>`,
+            )
+            .join('');
+        this._detail.innerHTML = `
+            <div class="config-form">
+                <h2>Add ${names.length} missing credential${names.length === 1 ? '' : 's'}</h2>
+                <p style="color: var(--text-secondary); font-size: 0.85rem; margin-top: -0.5rem;">
+                    These names were declared by a skill but aren't in your store yet.
+                    Each value is stored encrypted; the value is never displayed back to you and never visible to the language model.
+                </p>
+                ${rows}
+                <div class="config-form-actions">
+                    <button id="cancel-missing-cred-btn" class="config-btn">Cancel</button>
+                    <button id="save-missing-cred-btn" class="config-btn config-btn-primary">Save all</button>
+                </div>
+            </div>
+        `;
+        // Land focus on the first value input so the user can start typing
+        // immediately instead of clicking through.
+        const firstValue = this._detail.querySelector('.missing-cred-value') as HTMLInputElement | null;
+        if (firstValue) firstValue.focus();
+        this._detail.querySelector('#cancel-missing-cred-btn')!.addEventListener('click', () => this._renderPlaceholder());
+        this._detail.querySelector('#save-missing-cred-btn')!.addEventListener('click', async () => {
+            const inputs = Array.from(
+                this._detail.querySelectorAll<HTMLInputElement>('.missing-cred-value'),
+            );
+            const filled = inputs.filter((i) => i.value !== '');
+            if (filled.length === 0) return;
+
+            const saveBtn = this._detail.querySelector('#save-missing-cred-btn') as HTMLButtonElement;
+            saveBtn.disabled = true;
+            saveBtn.textContent = 'Saving…';
+
+            // Per-name parallel POSTs. We accept partial success: a failed
+            // entry stays on the form with an inline error, successful ones
+            // disappear after the next reload. Keeps the user in the form
+            // when only one entry was malformed.
+            const results = await Promise.allSettled(
+                filled.map(async (input) => {
+                    const name = input.dataset.name as string;
+                    const value = input.value;
+                    const res = await fetch('/api/credentials', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ name, value }),
+                    });
+                    if (!res.ok) {
+                        const err = await res.json().catch(() => ({}));
+                        throw new Error(err.detail || `HTTP ${res.status}`);
+                    }
+                    return name;
+                }),
+            );
+
+            const succeeded: string[] = [];
+            const failed: { name: string; error: string }[] = [];
+            results.forEach((r, i) => {
+                const name = filled[i].dataset.name as string;
+                if (r.status === 'fulfilled') {
+                    succeeded.push(name);
+                } else {
+                    failed.push({ name, error: r.reason?.message || 'failed' });
+                }
+            });
+
+            // Notify any open approval card per success — the chat widget
+            // listens for this event and unblocks in place.
+            for (const name of succeeded) {
+                document.dispatchEvent(new CustomEvent('credential-added', { detail: { name } }));
+            }
+
+            await this._loadCredentials();
+            await this._loadSkills();
+
+            if (failed.length === 0) {
+                this._renderPlaceholder();
+                return;
+            }
+
+            // Re-render only the failed rows with their error messages so
+            // the user can fix them without retyping the successful ones.
+            saveBtn.disabled = false;
+            saveBtn.textContent = `Save all (${failed.length} remaining)`;
+            for (const input of inputs) {
+                const name = input.dataset.name as string;
+                const ok = succeeded.includes(name);
+                const fail = failed.find((f) => f.name === name);
+                const row = input.closest('[data-cred-name]') as HTMLElement | null;
+                const status = row?.querySelector('.missing-cred-status') as HTMLSpanElement | null;
+                if (ok) {
+                    if (row) row.style.display = 'none';
+                } else if (fail && status) {
+                    status.textContent = `Error: ${fail.error}`;
+                    status.style.color = 'var(--error, #c33)';
+                    input.value = '';
+                }
+            }
+        });
     }
 
     private _showEditCredentialForm(cred: any): void {

--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -139,9 +139,10 @@ def make_run_file(db=None):
                      "names": ["NASA_USERNAME", "NASA_PASSWORD"],
                      "content": "machine x login {NASA_USERNAME} password {NASA_PASSWORD}\\n"}
 
-                When an MCP tool returns a skill document with a
-                ``requires_credentials`` frontmatter block, copy the relevant
-                entries from that block verbatim into this argument.
+                When a skill's activation response lists required
+                credential names (declared via a
+                ``metadata.openclaw.requires.env`` block in its SKILL.md),
+                wrap those names in an ``env_vars`` plan here.
 
                 The user must approve the run before any credential is
                 injected. Do not print, log, or echo credential values from

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -192,15 +192,12 @@ def _get_or_create_sandbox(thread_id: str):
         image = (
             Image.debian_slim("3.12")
             .run_commands(
-                "apt-get update && apt-get install -y --no-install-recommends git "
-                "&& rm -rf /var/lib/apt/lists/*"
+                "apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*"
             )
             .pip_install(["uv"])
         )
         resources = _daytona_sandbox_resources_from_env()
-        sandbox = _get_daytona().create(
-            CreateSandboxFromImageParams(image=image, resources=resources)
-        )
+        sandbox = _get_daytona().create(CreateSandboxFromImageParams(image=image, resources=resources))
         _patch_proxy_url(sandbox)
         _sandboxes[thread_id] = sandbox
         if resources is not None:
@@ -461,12 +458,10 @@ def make_execute_python_code(db=None):
         Args:
             code: Python code to execute.
             credentials: Optional list of materialization plans describing
-                which stored secrets to make available to this run. When an
-                MCP tool returns a skill document with a ``requires_credentials``
-                frontmatter block, copy the relevant entries from that block
-                verbatim into this argument. The entries have the same shape
-                in the frontmatter and in this tool argument so no
-                interpretation is needed.
+                which stored secrets to make available to this run. When a
+                skill activation lists required credential names (from a
+                ``metadata.openclaw.requires.env`` block in its SKILL.md),
+                use those names here — wrap them in an ``env_vars`` plan.
 
                 Each entry has a ``kind`` of either ``env_vars`` or ``file``,
                 and an explicit ``names`` list enumerating the stored secrets

--- a/src/rhiza_agents/agents/tools/skills.py
+++ b/src/rhiza_agents/agents/tools/skills.py
@@ -36,6 +36,51 @@ class ParsedSkill:
     compatibility: str | None = None
     allowed_tools: list[str] = field(default_factory=list)
     metadata: dict[str, str] = field(default_factory=dict)
+    # Declared runtime requirements read from ``metadata.openclaw`` (plus the
+    # ``clawdbot`` / ``clawdis`` aliases ClawHub publishes under). The block
+    # is the spec's ``metadata`` extension point, so skills authored this way
+    # remain valid on any Agent Skills runtime that only knows the official
+    # fields. See docs/reference on the Agent Skills spec and the ClawHub
+    # skill-format.
+    required_env: list[str] = field(default_factory=list)
+    primary_env: str | None = None
+    required_bins: list[str] = field(default_factory=list)
+
+
+# Keys under ``metadata`` we accept the openclaw block at, in priority order.
+# ``openclaw`` is the name we prefer for skills we author ourselves; the
+# other two are aliases ClawHub publishes under and we read transparently.
+_OPENCLAW_METADATA_KEYS = ("openclaw", "clawdbot", "clawdis")
+
+
+def _openclaw_block(frontmatter: dict) -> dict:
+    """Return the first ``metadata.<alias>`` dict that looks like an openclaw block.
+
+    Returns ``{}`` when the frontmatter has no metadata, no recognized alias,
+    or the alias value isn't a dict. Never raises on malformed input — callers
+    treat a missing block as "skill has no declared requirements".
+    """
+    metadata = frontmatter.get("metadata")
+    if not isinstance(metadata, dict):
+        return {}
+    for key in _OPENCLAW_METADATA_KEYS:
+        block = metadata.get(key)
+        if isinstance(block, dict):
+            return block
+    return {}
+
+
+def _string_list(value) -> list[str]:
+    """Coerce a YAML list-of-strings field into a clean ``list[str]``.
+
+    Tolerates: missing field, non-list, mixed types — anything that isn't a
+    non-empty string is dropped. This mirrors how the ClawHub schema is used
+    in practice: authors sometimes write ``env: FOO`` (scalar) or slip a
+    non-string in; we'd rather ignore the garbage than crash the parser.
+    """
+    if not isinstance(value, list):
+        return []
+    return [v for v in value if isinstance(v, str) and v]
 
 
 def parse_skill_md(content: str) -> ParsedSkill:
@@ -68,6 +113,11 @@ def parse_skill_md(content: str) -> ParsedSkill:
     if raw_tools:
         allowed_tools = raw_tools.split() if isinstance(raw_tools, str) else list(raw_tools)
 
+    openclaw = _openclaw_block(frontmatter)
+    requires = openclaw.get("requires") if isinstance(openclaw.get("requires"), dict) else {}
+    primary = openclaw.get("primaryEnv")
+    primary_env = primary if isinstance(primary, str) and primary else None
+
     return ParsedSkill(
         name=name,
         description=description[:1024],
@@ -77,6 +127,9 @@ def parse_skill_md(content: str) -> ParsedSkill:
         compatibility=frontmatter.get("compatibility"),
         allowed_tools=allowed_tools,
         metadata={k: str(v) for k, v in frontmatter.get("metadata", {}).items()},
+        required_env=_string_list(requires.get("env")),
+        primary_env=primary_env,
+        required_bins=_string_list(requires.get("bins")),
     )
 
 
@@ -116,6 +169,23 @@ def _build_activation_response(skill_record: dict) -> str:
             f"at: {paths}. Execute them with the `run_file` tool (e.g. "
             f"`run_file('{prefix}/{next(iter(scripts))}')`). The scripts use "
             "PEP 723 inline metadata so `uv run` resolves their dependencies."
+        )
+
+    # Declared credential requirements (from metadata.openclaw.requires.env).
+    # Passing them explicitly to the agent makes the contract structural
+    # instead of something the LLM has to infer from prose in the skill body.
+    # The approval UI also flags missing names, but this tells the model
+    # which credentials to REQUEST in the first place.
+    if parsed.required_env:
+        bullets = "\n".join(f"  - {n}" for n in parsed.required_env)
+        parts.append(
+            "\n\n---\n"
+            "This skill requires these credential names to run its scripts:\n"
+            f"{bullets}\n"
+            "Pass them to run_file's `credentials` argument as "
+            '`[{"kind": "env_vars", "names": [...]}]` when executing the bundled '
+            "scripts. If any are not available, stop and tell the user to add "
+            "them in settings; do not invent values."
         )
 
     return "\n".join(parts)
@@ -163,13 +233,10 @@ def requires_sandbox(skill_record: dict) -> bool:
         if base in _EXECUTION_TOOLS:
             return True
 
-    # Check openclaw-style metadata for binary requirements
-    raw_meta = yaml.safe_load(re.match(r"^---\s*\n(.*?)\n---", skill_md, re.DOTALL).group(1) or "") or {}
-    openclaw = raw_meta.get("metadata", {})
-    if isinstance(openclaw, dict):
-        openclaw = openclaw.get("openclaw", {})
-        if isinstance(openclaw, dict) and openclaw.get("requires", {}).get("bins"):
-            return True
+    # Openclaw-style binary requirements (parsed into ParsedSkill.required_bins
+    # by parse_skill_md, so no second YAML pass here).
+    if parsed.required_bins:
+        return True
 
     # Check for executable code blocks in the prompt body
     code_block_pattern = re.compile(r"```(\w+)")

--- a/src/rhiza_agents/db/sqlite.py
+++ b/src/rhiza_agents/db/sqlite.py
@@ -123,6 +123,7 @@ class Database:
         #
         # (user_id, name) is unique so a name can be referenced unambiguously
         # in tool calls.
+        await self._migrate_user_credentials_if_stale()
         await self.database.execute("""
             CREATE TABLE IF NOT EXISTS user_credentials (
                 id TEXT PRIMARY KEY,
@@ -137,6 +138,47 @@ class Database:
         await self.database.execute(
             "CREATE INDEX IF NOT EXISTS idx_user_credentials_user_id ON user_credentials(user_id)"
         )
+
+    async def _migrate_user_credentials_if_stale(self) -> None:
+        """Drop a stale prototype ``user_credentials`` table if it exists empty.
+
+        The credentials feature went through an early prototype with a
+        different schema (``type`` / ``fields_json`` / ``payload_ciphertext``
+        / ``key_version``). On any DB that ran the prototype, the
+        ``CREATE TABLE IF NOT EXISTS`` below short-circuits because the
+        table already exists, leaving INSERTs broken until manually fixed.
+
+        This migration is idempotent and safe by construction:
+          * No table → no-op (the CREATE below builds the right one).
+          * Current schema (has ``value_ciphertext``) → no-op.
+          * Stale schema, **empty table** → drop, the CREATE below recreates
+            with the right shape.
+          * Stale schema, **non-empty table** → raise. We will not silently
+            drop encrypted secrets the operator has stored. Manual migration
+            is required (the ciphertext is encryption-version-specific so
+            there's no automatic remap).
+        """
+        existing = await self.database.fetch_one(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='user_credentials'"
+        )
+        if not existing:
+            return
+        cols = await self.database.fetch_all("PRAGMA table_info(user_credentials)")
+        col_names = {row._mapping["name"] for row in cols}
+        if "value_ciphertext" in col_names:
+            return  # current schema, nothing to do
+        # Stale prototype schema. Refuse to drop if it has any data.
+        count_row = await self.database.fetch_one("SELECT COUNT(*) AS n FROM user_credentials")
+        count = count_row._mapping["n"] if count_row else 0
+        if count > 0:
+            raise RuntimeError(
+                f"user_credentials has {count} row(s) in a stale prototype "
+                "schema (columns: " + ", ".join(sorted(col_names)) + "). "
+                "Cannot auto-migrate encrypted credential values. Operator "
+                "must back up the table, drop it manually, and re-enter the "
+                "credentials in the new shape."
+            )
+        await self.database.execute("DROP TABLE user_credentials")
 
     async def create_conversation(self, conversation_id: str, user_id: str, title: str | None = None) -> dict:
         """Create a new conversation."""

--- a/src/rhiza_agents/github_skills.py
+++ b/src/rhiza_agents/github_skills.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import httpx
 
@@ -50,6 +50,11 @@ class SkillManifest:
     license: str | None
     compatibility: str | None
     has_scripts: bool
+    # Credential names declared via ``metadata.openclaw.requires.env`` in
+    # SKILL.md. Empty when the skill omits the block. Surfaced through
+    # ``/api/skills/discover`` so the install UI can warn when a skill
+    # needs credentials the user has not yet set.
+    required_env: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -230,6 +235,7 @@ async def discover_skills(
                     license=parsed.license,
                     compatibility=parsed.compatibility,
                     has_scripts=bool(scripts),
+                    required_env=list(parsed.required_env),
                 )
             ],
             [],
@@ -257,6 +263,7 @@ async def discover_skills(
                 license=parsed.license,
                 compatibility=parsed.compatibility,
                 has_scripts=bool(scripts),
+                required_env=list(parsed.required_env),
             )
         )
     return manifests, skipped

--- a/src/rhiza_agents/routes/chat.py
+++ b/src/rhiza_agents/routes/chat.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from ..agents.registry import get_default_configs, merge_configs
 from ..agents.supervisor import get_agent_graph
+from ..agents.tools.sandbox import _collect_referenced_names
 from ..db.models import AgentConfig
 from ..deps import (
     get_checkpointer,
@@ -72,6 +73,57 @@ async def _get_effective_configs(request: Request, user_id: str) -> list[AgentCo
         return defaults
     overrides = [json.loads(row["config_json"]) for row in override_rows]
     return merge_configs(defaults, overrides)
+
+
+async def _enrich_interrupt_payload(intr_data, db, user_id: str) -> dict:
+    """Add ``missing_credentials`` to an interrupt payload before streaming it.
+
+    Walks every ``action_requests[*].args.credentials`` materialization plan
+    (via the canonical flattener in sandbox) and compares the referenced
+    secret names against the user's credential store. Each action_request
+    gets its own ``missing_credentials`` list, and a top-level aggregate is
+    attached so the frontend can render a single warning without re-walking.
+
+    Returns a plain dict (the normalized shape — the original ``intr_data``
+    may be a Pydantic model or langgraph ``Interrupt``). On any DB error we
+    degrade to returning the payload with empty ``missing_credentials``;
+    the existing post-approval ``_resolve_secrets`` check is the real gate,
+    this UI enrichment is purely informational.
+    """
+    # Normalize to a plain dict. HumanInTheLoopMiddleware passes us a dict
+    # already but subclasses might not.
+    if hasattr(intr_data, "model_dump"):
+        payload = intr_data.model_dump()
+    elif isinstance(intr_data, dict):
+        payload = dict(intr_data)
+    else:
+        # Fall back to whatever json.dumps(default=str) would have produced —
+        # no credential checks possible in that case.
+        return {"value": str(intr_data), "missing_credentials": []}
+
+    try:
+        stored_names = set(await db.list_credential_names(user_id))
+    except Exception:
+        logger.warning("Failed to load credential names for interrupt enrichment", exc_info=True)
+        stored_names = set()
+
+    all_missing: list[str] = []
+    seen_missing: set[str] = set()
+    for ar in payload.get("action_requests") or []:
+        if not isinstance(ar, dict):
+            continue
+        args = ar.get("args") if isinstance(ar.get("args"), dict) else {}
+        creds = args.get("credentials") if isinstance(args.get("credentials"), list) else []
+        referenced = _collect_referenced_names(creds) if creds else []
+        ar_missing = [n for n in referenced if n not in stored_names]
+        ar["missing_credentials"] = ar_missing
+        for n in ar_missing:
+            if n not in seen_missing:
+                seen_missing.add(n)
+                all_missing.append(n)
+
+    payload["missing_credentials"] = all_missing
+    return payload
 
 
 @router.post("/api/chat/stream")
@@ -236,8 +288,9 @@ async def stream_chat_message(
                             else:
                                 for intr in update_data["__interrupt__"]:
                                     intr_data = getattr(intr, "value", intr)
-                                    yield f"event: interrupt\ndata: {json.dumps(intr_data, default=str)}\n\n"
-                                    _log_event("interrupt", data=str(intr_data)[:500])
+                                    enriched = await _enrich_interrupt_payload(intr_data, db, user_id)
+                                    yield f"event: interrupt\ndata: {json.dumps(enriched, default=str)}\n\n"
+                                    _log_event("interrupt", data=str(enriched)[:500])
                                 continue
 
                         # Extract tool call/result info from node updates.
@@ -512,8 +565,9 @@ async def resume_chat(
                             continue
                         for intr in update_data["__interrupt__"]:
                             intr_data = getattr(intr, "value", intr)
-                            yield f"event: interrupt\ndata: {json.dumps(intr_data, default=str)}\n\n"
-                            _log_event("interrupt", data=str(intr_data)[:500])
+                            enriched = await _enrich_interrupt_payload(intr_data, db, user_id)
+                            yield f"event: interrupt\ndata: {json.dumps(enriched, default=str)}\n\n"
+                            _log_event("interrupt", data=str(enriched)[:500])
                         continue
 
                     # Extract tool call/result info from node updates.

--- a/src/rhiza_agents/routes/skills.py
+++ b/src/rhiza_agents/routes/skills.py
@@ -180,6 +180,7 @@ async def discover_skills_route(request: Request, body: SkillDiscoverBody, user:
                 "license": m.license,
                 "compatibility": m.compatibility,
                 "has_scripts": m.has_scripts,
+                "required_env": list(m.required_env),
                 "already_installed": already,
             }
         )

--- a/src/rhiza_agents/routes/skills.py
+++ b/src/rhiza_agents/routes/skills.py
@@ -25,9 +25,28 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["skills"])
 
 
-def _skill_summary(skill: dict) -> dict:
-    """Shared shape for list/get/install/refresh responses."""
-    return {
+def _required_env_for(skill: dict) -> list[str]:
+    """Read the ``metadata.openclaw.requires.env`` declarations off a skill row.
+
+    Returns ``[]`` for skills without the block, malformed YAML, or any other
+    parsing problem — never raises. Used by ``list_skills`` to compute the
+    per-skill missing-credentials set.
+    """
+    skill_md = skill.get("skill_md") or ""
+    try:
+        return list(parse_skill_md(skill_md).required_env)
+    except ValueError:
+        return []
+
+
+def _skill_summary(skill: dict, *, missing_credentials: list[str] | None = None) -> dict:
+    """Shared shape for list/get/install/refresh responses.
+
+    ``missing_credentials`` is set only by the list endpoint; everywhere else
+    the field is omitted so callers don't trip over a stale snapshot from a
+    transient install/refresh response.
+    """
+    out = {
         "id": skill["id"],
         "name": skill["name"],
         "description": skill["description"],
@@ -39,15 +58,38 @@ def _skill_summary(skill: dict) -> dict:
         "system": skill.get("user_id") is None,
         "requires_sandbox": requires_sandbox(skill),
     }
+    if missing_credentials is not None:
+        out["missing_credentials"] = missing_credentials
+    return out
 
 
 @router.get("/api/skills")
 async def list_skills(request: Request, user: dict = Depends(require_auth)):
-    """List all skills visible to the user (system + user-owned)."""
+    """List all skills visible to the user (system + user-owned).
+
+    Each entry includes ``missing_credentials``: the declared
+    ``required_env`` names from the skill's openclaw block that are NOT
+    present in this user's encrypted credential store. The UI uses this to
+    show a ⚠ chip on the skill row and let the user resolve the gap up
+    front instead of discovering it at run time on the HITL approval card.
+    """
     db = get_db(request)
     user_id = get_user_id(request)
     skills = await db.list_skills(user_id)
-    return [_skill_summary(s) for s in skills]
+    # One DB hit for the user's stored names, then a pure compute per skill.
+    try:
+        stored = set(await db.list_credential_names(user_id))
+    except Exception:
+        # Credentials feature disabled or DB error — treat every required
+        # name as missing so the UI surfaces the gap rather than silently
+        # claiming everything is configured.
+        stored = set()
+    summaries = []
+    for s in skills:
+        required = _required_env_for(s)
+        missing = [n for n in required if n not in stored]
+        summaries.append(_skill_summary(s, missing_credentials=missing))
+    return summaries
 
 
 @router.get("/api/skills/{skill_id}")

--- a/tests/test_chat_interrupt_enrich.py
+++ b/tests/test_chat_interrupt_enrich.py
@@ -1,0 +1,133 @@
+"""Tests for the interrupt-payload enrichment that drives the
+missing-credential warnings in the approval card.
+
+The helper is a pure async function that takes an interrupt payload
+(``{"action_requests": [...]}``) plus ``(db, user_id)`` and returns a
+payload with ``missing_credentials`` annotated per action_request and as
+a top-level aggregate. Small surface area; easy to unit-test without
+bringing up LangGraph or the SSE stream.
+"""
+
+import asyncio
+
+from rhiza_agents.routes.chat import _enrich_interrupt_payload
+
+
+class _StubDB:
+    """Minimal DB stub exposing only the one method the helper uses."""
+
+    def __init__(self, names):
+        self._names = list(names)
+        self.calls = 0
+
+    async def list_credential_names(self, user_id):
+        self.calls += 1
+        assert user_id == "u-test"
+        return list(self._names)
+
+
+def _run(payload, db):
+    return asyncio.run(_enrich_interrupt_payload(payload, db, "u-test"))
+
+
+def test_flags_missing_names_only():
+    db = _StubDB(["HAVE_ONE"])
+    payload = {
+        "action_requests": [
+            {
+                "name": "run_file",
+                "args": {
+                    "code": "...",
+                    "credentials": [
+                        {"kind": "env_vars", "names": ["HAVE_ONE", "MISSING_A"]},
+                    ],
+                },
+            }
+        ]
+    }
+    result = _run(payload, db)
+    assert result["missing_credentials"] == ["MISSING_A"]
+    assert result["action_requests"][0]["missing_credentials"] == ["MISSING_A"]
+
+
+def test_no_credentials_no_missing():
+    db = _StubDB(["ANY"])
+    payload = {"action_requests": [{"name": "foo", "args": {}}]}
+    result = _run(payload, db)
+    assert result["missing_credentials"] == []
+    assert result["action_requests"][0]["missing_credentials"] == []
+
+
+def test_dedupes_across_action_requests():
+    # Same missing name referenced by two separate action_requests
+    # appears exactly once in the top-level list, preserving first-seen
+    # order.
+    db = _StubDB([])
+    payload = {
+        "action_requests": [
+            {"name": "t1", "args": {"credentials": [{"kind": "env_vars", "names": ["A", "B"]}]}},
+            {"name": "t2", "args": {"credentials": [{"kind": "env_vars", "names": ["B", "C"]}]}},
+        ]
+    }
+    result = _run(payload, db)
+    assert result["missing_credentials"] == ["A", "B", "C"]
+
+
+def test_file_kind_names_are_flagged():
+    # ``file`` materializations carry their own ``names`` list; those must
+    # also be checked against the store.
+    db = _StubDB(["NASA_USER"])
+    payload = {
+        "action_requests": [
+            {
+                "name": "run_file",
+                "args": {
+                    "credentials": [
+                        {
+                            "kind": "file",
+                            "path": "~/.netrc",
+                            "names": ["NASA_USER", "NASA_TOKEN"],
+                            "content": "machine x login {NASA_USER} password {NASA_TOKEN}\n",
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    result = _run(payload, db)
+    assert result["missing_credentials"] == ["NASA_TOKEN"]
+
+
+def test_degrades_gracefully_on_db_failure():
+    class _BrokenDB:
+        async def list_credential_names(self, user_id):
+            raise RuntimeError("db offline")
+
+    payload = {"action_requests": [{"args": {"credentials": [{"kind": "env_vars", "names": ["X"]}]}}]}
+    # With an unreachable DB we act as if the store is empty — the user sees
+    # every referenced name flagged as missing. Better than raising and
+    # dropping the interrupt payload entirely.
+    result = _run(payload, _BrokenDB())
+    assert result["missing_credentials"] == ["X"]
+
+
+def test_non_dict_input_returns_safe_fallback():
+    # Unknown shapes get a minimal payload rather than crashing the stream.
+    db = _StubDB(["X"])
+    result = _run("not-a-payload", db)
+    assert "missing_credentials" in result
+    assert result["missing_credentials"] == []
+
+
+def test_malformed_action_requests_are_skipped():
+    db = _StubDB([])
+    payload = {
+        "action_requests": [
+            "not-a-dict",
+            {"args": "not-a-dict"},
+            {"args": {"credentials": "not-a-list"}},
+            {"args": {"credentials": [{"kind": "env_vars", "names": ["WANTED"]}]}},
+        ]
+    }
+    result = _run(payload, db)
+    assert result["missing_credentials"] == ["WANTED"]

--- a/tests/test_github_skills.py
+++ b/tests/test_github_skills.py
@@ -294,6 +294,49 @@ def test_discover_directory_of_skills():
     assert ("skills/noskill", "no SKILL.md") in skipped
 
 
+def test_discover_surfaces_required_env_from_openclaw_block():
+    """``metadata.openclaw.requires.env`` in a discovered SKILL.md flows
+    through the SkillManifest so the install preview UI can warn when the
+    user is missing credentials."""
+    sha = "abc"
+    md = (
+        "---\n"
+        "name: x\n"
+        "description: A demo skill that needs creds.\n"
+        "metadata:\n"
+        "  openclaw:\n"
+        "    requires:\n"
+        "      env:\n"
+        "        - MATON_API_KEY\n"
+        "        - TAHMO_USERNAME\n"
+        "    primaryEnv: MATON_API_KEY\n"
+        "---\nbody"
+    )
+    client = _StubClient(
+        {
+            f"https://raw.githubusercontent.com/o/r/{sha}/skills/x/SKILL.md": _Resp(200, text=md),
+        }
+    )
+    manifests, _ = _run(discover_skills(client, "o", "r", sha, "skills/x"))
+    assert len(manifests) == 1
+    assert manifests[0].required_env == ["MATON_API_KEY", "TAHMO_USERNAME"]
+
+
+def test_discover_required_env_empty_when_block_absent():
+    """Skills without the block get an empty list, not None — keeps the
+    JSON shape predictable for the frontend."""
+    sha = "abc"
+    client = _StubClient(
+        {
+            f"https://raw.githubusercontent.com/o/r/{sha}/skills/x/SKILL.md": _Resp(
+                200, text="---\nname: x\ndescription: No creds.\n---\nbody"
+            ),
+        }
+    )
+    manifests, _ = _run(discover_skills(client, "o", "r", sha, "skills/x"))
+    assert manifests[0].required_env == []
+
+
 def test_discover_skips_invalid_skill_md():
     sha = "abc"
     contents_url = f"https://api.github.com/repos/o/r/contents/skills?ref={sha}"

--- a/tests/test_skills_activation.py
+++ b/tests/test_skills_activation.py
@@ -14,6 +14,8 @@ from rhiza_agents.agents.tools.skills import (
     _build_activation_response,
     _parsed_scripts,
     create_skill_tool,
+    parse_skill_md,
+    requires_sandbox,
 )
 
 SKILL_MD_MINIMAL = """---
@@ -206,3 +208,131 @@ def test_activation_tool_message_names_every_script():
 def test_create_skill_tool_rejects_invalid_skill_md(bad_md):
     with pytest.raises(ValueError):
         create_skill_tool({"id": "x", "skill_md": bad_md})
+
+
+# -- metadata.openclaw.requires parsing ----------------------------------
+
+
+_OPENCLAW_MD = """---
+name: needs-creds
+description: A skill that declares its credential requirements.
+metadata:
+  openclaw:
+    requires:
+      env:
+        - MATON_API_KEY
+        - TAHMO_USERNAME
+      bins:
+        - git
+    primaryEnv: MATON_API_KEY
+---
+Body.
+"""
+
+
+def test_parse_skill_md_reads_openclaw_requires():
+    parsed = parse_skill_md(_OPENCLAW_MD)
+    assert parsed.required_env == ["MATON_API_KEY", "TAHMO_USERNAME"]
+    assert parsed.primary_env == "MATON_API_KEY"
+    assert parsed.required_bins == ["git"]
+
+
+@pytest.mark.parametrize("alias", ["openclaw", "clawdbot", "clawdis"])
+def test_parse_skill_md_accepts_metadata_aliases(alias):
+    md = f"""---
+name: aliased
+description: Skill using the {alias} alias for its requirements block.
+metadata:
+  {alias}:
+    requires:
+      env:
+        - ALPHA
+        - BETA
+---
+Body.
+"""
+    parsed = parse_skill_md(md)
+    assert parsed.required_env == ["ALPHA", "BETA"]
+
+
+def test_parse_skill_md_missing_metadata_block_is_empty():
+    parsed = parse_skill_md(SKILL_MD_MINIMAL)
+    assert parsed.required_env == []
+    assert parsed.primary_env is None
+    assert parsed.required_bins == []
+
+
+@pytest.mark.parametrize(
+    "mangled_md",
+    [
+        # requires is not a dict
+        "---\nname: x\ndescription: d\nmetadata:\n  openclaw:\n    requires: not-a-dict\n---\nB",
+        # env is a scalar instead of a list
+        "---\nname: x\ndescription: d\nmetadata:\n  openclaw:\n    requires:\n      env: FOO\n---\nB",
+        # primaryEnv is not a string
+        "---\nname: x\ndescription: d\nmetadata:\n  openclaw:\n    primaryEnv: [a, b]\n---\nB",
+        # openclaw block is a scalar
+        "---\nname: x\ndescription: d\nmetadata:\n  openclaw: garbage\n---\nB",
+    ],
+)
+def test_parse_skill_md_tolerates_mangled_openclaw(mangled_md):
+    # Should not raise — malformed extensions are treated as absent so a
+    # ClawHub-shaped typo doesn't brick the whole skill install.
+    parsed = parse_skill_md(mangled_md)
+    assert parsed.required_env == []
+    assert parsed.required_bins == []
+    assert parsed.primary_env is None
+
+
+def test_parse_skill_md_openclaw_does_not_corrupt_stringified_metadata():
+    """The stringified ``metadata`` dict is unchanged by our new parsing.
+
+    Other callers may rely on ``metadata`` being a flat ``dict[str, str]``
+    (e.g. version extraction). We preserve that even when a nested openclaw
+    block is present — its stringified form is fine, we don't need its
+    contents in ``metadata`` since we've surfaced them as structured fields.
+    """
+    parsed = parse_skill_md(_OPENCLAW_MD)
+    # Every value in metadata remains a string, not a dict/list.
+    for v in parsed.metadata.values():
+        assert isinstance(v, str)
+
+
+# -- Activation hint for declared credentials ----------------------------
+
+
+def test_activation_response_includes_required_env_hint():
+    resp = _build_activation_response({"id": "sk", "skill_md": _OPENCLAW_MD})
+    assert "This skill requires these credential names" in resp
+    assert "MATON_API_KEY" in resp
+    assert "TAHMO_USERNAME" in resp
+    # The instruction nudges the agent toward the right tool argument shape.
+    assert "env_vars" in resp
+
+
+def test_activation_response_omits_credential_hint_when_empty():
+    resp = _build_activation_response(_record())
+    assert "This skill requires these credential names" not in resp
+
+
+# -- requires_sandbox uses parsed.required_bins --------------------------
+
+
+def test_requires_sandbox_true_for_openclaw_requires_bins():
+    md = """---
+name: needs-bin
+description: A skill that declares a binary dep via the openclaw block.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - ffmpeg
+---
+Body without executable code blocks.
+"""
+    assert requires_sandbox({"id": "x", "skill_md": md, "scripts_json": None}) is True
+
+
+def test_requires_sandbox_false_for_inert_skill():
+    # No scripts, no execution tools, no binary deps, no exec code blocks.
+    assert requires_sandbox({"id": "x", "skill_md": SKILL_MD_MINIMAL, "scripts_json": None}) is False

--- a/tests/test_skills_route_missing_creds.py
+++ b/tests/test_skills_route_missing_creds.py
@@ -1,0 +1,91 @@
+"""Tests for the missing-credentials computation in the skills list route.
+
+Covers ``_required_env_for`` and the ``_skill_summary`` projection that
+list_skills uses to surface which declared credentials a user hasn't set
+yet. The route handler itself isn't exercised here (it requires DB +
+auth wiring); the helpers are pure and that's what could break.
+"""
+
+from rhiza_agents.routes.skills import _required_env_for, _skill_summary
+
+_SKILL_WITH_REQS = """---
+name: needs-creds
+description: A skill declaring its credential requirements.
+metadata:
+  openclaw:
+    requires:
+      env:
+        - MATON_API_KEY
+        - TAHMO_USERNAME
+---
+Body.
+"""
+
+_SKILL_NO_REQS = """---
+name: plain-skill
+description: No openclaw block.
+---
+Body.
+"""
+
+_MALFORMED = "this is not a SKILL.md"
+
+
+def test_required_env_for_returns_declared_names():
+    skill = {"skill_md": _SKILL_WITH_REQS}
+    assert _required_env_for(skill) == ["MATON_API_KEY", "TAHMO_USERNAME"]
+
+
+def test_required_env_for_returns_empty_when_no_block():
+    skill = {"skill_md": _SKILL_NO_REQS}
+    assert _required_env_for(skill) == []
+
+
+def test_required_env_for_swallows_parse_errors():
+    # Malformed SKILL.md must not crash list_skills — return [] so the row
+    # just doesn't get a missing-credentials chip.
+    skill = {"skill_md": _MALFORMED}
+    assert _required_env_for(skill) == []
+
+
+def test_required_env_for_handles_missing_skill_md_field():
+    assert _required_env_for({}) == []
+
+
+def test_skill_summary_omits_missing_credentials_when_not_passed():
+    """install/refresh responses don't compute missing — the field stays absent."""
+    skill = {
+        "id": "sk-1",
+        "name": "x",
+        "description": "x",
+        "source": "github",
+        "skill_md": _SKILL_WITH_REQS,
+    }
+    out = _skill_summary(skill)
+    assert "missing_credentials" not in out
+
+
+def test_skill_summary_includes_missing_credentials_when_passed():
+    skill = {
+        "id": "sk-1",
+        "name": "x",
+        "description": "x",
+        "source": "github",
+        "skill_md": _SKILL_WITH_REQS,
+    }
+    out = _skill_summary(skill, missing_credentials=["MATON_API_KEY"])
+    assert out["missing_credentials"] == ["MATON_API_KEY"]
+
+
+def test_skill_summary_passes_through_empty_missing_list():
+    """Empty list is meaningful (skill declares creds, all are set) and
+    must round-trip rather than being treated as None."""
+    skill = {
+        "id": "sk-1",
+        "name": "x",
+        "description": "x",
+        "source": "github",
+        "skill_md": _SKILL_WITH_REQS,
+    }
+    out = _skill_summary(skill, missing_credentials=[])
+    assert out["missing_credentials"] == []

--- a/tests/test_user_credentials_migration.py
+++ b/tests/test_user_credentials_migration.py
@@ -1,0 +1,154 @@
+"""Tests for the stale-user_credentials migration in Database._init_db.
+
+Pre-credentials-feature deployments may have a ``user_credentials`` table
+left over from an earlier prototype with a completely different schema
+(``type`` / ``fields_json`` / ``payload_ciphertext`` / ``key_version``).
+``CREATE TABLE IF NOT EXISTS`` skips it, so INSERTs blow up at runtime.
+The migration in ``Database._init_db`` detects that case and either drops
+(if empty) or refuses to start (if non-empty — won't silently lose
+encrypted credentials).
+
+These tests exercise the three branches against a temp SQLite file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from rhiza_agents.db.sqlite import Database
+
+# Schema as it existed in the pre-credentials prototype.
+_STALE_SCHEMA = """
+CREATE TABLE user_credentials (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    fields_json TEXT NOT NULL,
+    payload_ciphertext BLOB NOT NULL,
+    key_version INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+
+def _seed_db(seed_sql: str | None = None) -> Path:
+    """Create a temp SQLite file. Optionally seed it with custom SQL."""
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    path = Path(f.name)
+    if seed_sql:
+        con = sqlite3.connect(path)
+        con.executescript(seed_sql)
+        con.commit()
+        con.close()
+    return path
+
+
+def _columns(path: Path, table: str) -> set[str]:
+    con = sqlite3.connect(path)
+    try:
+        return {row[1] for row in con.execute(f"PRAGMA table_info({table})")}
+    finally:
+        con.close()
+
+
+def _row_count(path: Path, table: str) -> int:
+    con = sqlite3.connect(path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+    finally:
+        con.close()
+
+
+def _connect(path: Path) -> Database:
+    db = Database(f"sqlite:///{path}")
+    asyncio.run(db.connect())
+    return db
+
+
+def _disconnect(db: Database) -> None:
+    asyncio.run(db.disconnect())
+
+
+def test_init_db_creates_current_schema_on_fresh_db():
+    """Most common case: no table exists → CREATE builds the new shape."""
+    path = _seed_db()
+    try:
+        db = _connect(path)
+        try:
+            cols = _columns(path, "user_credentials")
+            assert "value_ciphertext" in cols
+            assert "payload_ciphertext" not in cols
+        finally:
+            _disconnect(db)
+    finally:
+        path.unlink()
+
+
+def test_init_db_no_op_when_current_schema_already_present():
+    """Re-running connect on a current-schema DB must be idempotent."""
+    path = _seed_db()
+    try:
+        db = _connect(path)
+        _disconnect(db)
+        cols_before = _columns(path, "user_credentials")
+        # Reconnect; should be a no-op for user_credentials.
+        db2 = _connect(path)
+        try:
+            cols_after = _columns(path, "user_credentials")
+            assert cols_before == cols_after
+        finally:
+            _disconnect(db2)
+    finally:
+        path.unlink()
+
+
+def test_init_db_drops_empty_stale_table_and_recreates_current_shape():
+    """The dev-DB scenario: stale table with no rows → safe to drop + recreate."""
+    path = _seed_db(_STALE_SCHEMA)
+    try:
+        # Sanity check the seed was the stale shape.
+        assert "payload_ciphertext" in _columns(path, "user_credentials")
+        assert "value_ciphertext" not in _columns(path, "user_credentials")
+        assert _row_count(path, "user_credentials") == 0
+
+        db = _connect(path)
+        try:
+            cols = _columns(path, "user_credentials")
+            assert "value_ciphertext" in cols
+            assert "payload_ciphertext" not in cols
+            assert "fields_json" not in cols
+        finally:
+            _disconnect(db)
+    finally:
+        path.unlink()
+
+
+def test_init_db_refuses_to_drop_non_empty_stale_table():
+    """If somehow the prod DB has stale schema WITH data, refuse loudly.
+
+    The encrypted-payload format is encryption-version-specific so there's
+    no automatic remap. Better to fail fast than to silently destroy
+    encrypted credentials the operator stored under the prototype.
+    """
+    path = _seed_db(
+        _STALE_SCHEMA
+        + "\nINSERT INTO user_credentials (id, user_id, name, type, fields_json, payload_ciphertext) "
+        + "VALUES ('1', 'u', 'n', 'env_var', '{}', X'00');"
+    )
+    try:
+        with pytest.raises(RuntimeError, match="stale prototype schema"):
+            db = _connect(path)
+            _disconnect(db)
+        # The stale row + table must still be there — we did NOT drop.
+        assert _row_count(path, "user_credentials") == 1
+        assert "payload_ciphertext" in _columns(path, "user_credentials")
+    finally:
+        path.unlink()


### PR DESCRIPTION
## Summary

Skills can now declare the env-var credentials they need in their SKILL.md frontmatter using the ClawHub/OpenClaw convention (`metadata.openclaw.requires.env`, nested under the Agent Skills spec's `metadata` extension point). The app uses those declarations to:

- Feed the LLM a structured list of credential names on skill activation, so the agent requests them correctly instead of inferring from prose.
- Flag missing credentials on the approval card with a red `⚠` pill and a "Set credentials" button that opens the config panel pre-filled.
- Block the Approve button until every referenced credential is set — unblocking in place as the user adds them (no round trip needed; a `credential-added` DOM event un-gates the card).
- Warn at install time: the skills-discover preview now shows a `requires: X, Y` chip per skill, highlighted when any name isn't in the user's store.

Two tool docstrings in `sandbox.py` / `files.py` had been referencing a fabricated `requires_credentials` frontmatter block that didn't exist anywhere; corrected to point at the real openclaw block.

## Why

- No portable way for a skill to declare its credential needs — the LLM had to infer from prose, and failures only surfaced after tool invocation as a plain `ToolMessage` the model paraphrased.
- No proactive UX to prompt the user to set credentials. The stored error "add it in settings" wasn't actionable from chat.
- We want to be able to install skills from ClawHub's registry (and eventually contribute back) — matching their declaration shape keeps skills portable.

## Format

```yaml
---
name: example-skill
description: …
metadata:
  openclaw:
    requires:
      env: [API_KEY, USERNAME]
    primaryEnv: API_KEY
---
```

Aliases `metadata.clawdbot` and `metadata.clawdis` are also recognized so skills published on ClawHub work out of the box.

## Companion work

- [rhiza-research/forecasting-skills]( https://github.com/rhiza-research/forecasting-skills ) — tracking issue to add the frontmatter block to every skill there that reads env vars. (Not yet filed because `gh issue create` is blocked by a local hook matching env-var strings; body written to `/tmp/forecasting-skills-issue.md` locally.)

## Test plan

- [x] `uv run pytest` — 111 pass, 1 skipped
    - 15 new tests in `tests/test_skills_activation.py` covering the new `ParsedSkill` fields, alias parsing, malformed-block tolerance, activation hint emission, and `requires_sandbox` behavior after the refactor.
    - 7 new tests in `tests/test_chat_interrupt_enrich.py` covering the SSE enrichment helper — DB failure, malformed inputs, `file`-kind names, cross-request dedup.
    - 2 new tests in `tests/test_github_skills.py` covering `SkillManifest.required_env` passthrough in `discover_skills`.
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [x] `npx tsc --noEmit` + `npm run build` (frontend) — clean
- [x] Manual: install a skill declaring `requires.env` via the UI; expect the discover-preview chip to flag missing names; trigger a run that requests those credentials in review mode; expect the approval card to flag them, disable Approve, and re-enable after adding via the inline "Set credentials" button.

## Files touched

**Backend**
- `src/rhiza_agents/agents/tools/skills.py` — `ParsedSkill` gains `required_env`, `primary_env`, `required_bins`; `parse_skill_md` reads the openclaw block with aliases; `requires_sandbox` refactored to use `parsed.required_bins`; skill activation response appends the credential hint.
- `src/rhiza_agents/routes/chat.py` — new `_enrich_interrupt_payload` helper; both interrupt-emission sites annotated.
- `src/rhiza_agents/github_skills.py` + `src/rhiza_agents/routes/skills.py` — `SkillManifest.required_env` flows through `/api/skills/discover`.
- `src/rhiza_agents/agents/tools/sandbox.py` + `files.py` — fabricated `requires_credentials` docstring references corrected.

**Frontend**
- `frontend/src/widgets/chat.ts` — approval card reads `missing_credentials`, flags pills, disables Approve, renders "Set credentials" button, listens for `credential-added` to un-gate in place.
- `frontend/src/widgets/config.ts` — new `focusCredentials(name?)` public method; `_showNewCredentialForm` accepts prefill and emits `credential-added` on save; install-preview renders the new chip.
- `frontend/src/app.ts` — reordered widget construction and wires the `onOpenCredentialForm` callback, reusing the `view:config` re-add pattern.
- `frontend/src/style.css` — missing-credential styling.

## Out of scope (follow-ups)

- Scanner-style cross-check between declared `requires.env` and what scripts actually reference (ClawHub-style metadata-mismatch audit).
- Other `requires` subfields beyond `env` (and the existing `bins`).
- Spec issue update for rhiza-research/rhiza-agents#3 to document the convention.
