### PR TITLE
feat: make missing credentials non-fatal during skill execution

### DIFF
--- a/frontend/src/widgets/chat.ts
+++ b/frontend/src/widgets/chat.ts
@@ -468,9 +468,15 @@ export class ChatWidget extends Widget {
                </div>`
             : '';
 
+        // Missing credentials are informational, not blocking. The backend
+        // silently drops absent names from the materialization plan and the
+        // underlying CLI/script is responsible for failing with a clear
+        // message if a credential it actually needed wasn't injected. We
+        // still surface which names won't be available so the user can add
+        // them up front if they want.
         const missingBanner = missingSet.size > 0
             ? `<div class="interrupt-missing-banner">
-                   <span>${missingSet.size === 1 ? 'This credential is not set' : 'These credentials are not set'} — approve is disabled until they are added.</span>
+                   <span>${missingSet.size === 1 ? 'This credential is not set' : 'These credentials are not set'} — it will not be injected unless you add it.</span>
                    <button class="interrupt-set-creds">Set credentials</button>
                </div>`
             : '';
@@ -485,7 +491,7 @@ export class ChatWidget extends Widget {
                 <pre>${JSON.stringify(toolArgs, null, 2)}</pre>
             </details>
             <div class="interrupt-actions">
-                <button class="interrupt-approve"${missingSet.size > 0 ? ' disabled' : ''}>Approve</button>
+                <button class="interrupt-approve">Approve</button>
                 <button class="interrupt-reject">Reject</button>
             </div>
         `;
@@ -496,7 +502,6 @@ export class ChatWidget extends Widget {
 
         const approveBtn = card.querySelector<HTMLButtonElement>('.interrupt-approve')!;
         approveBtn.addEventListener('click', () => {
-            if (approveBtn.disabled) return;
             card.remove();
             this._resumeExecution('approve', null);
         });
@@ -522,14 +527,11 @@ export class ChatWidget extends Widget {
         this._messagesDiv.scrollTop = this._messagesDiv.scrollHeight;
     }
 
-    /** Called when ``credential-added`` fires. Walks every interrupt card
-     *  currently in the message area and, for each one that was gated on
-     *  ``name``, removes the pill's missing marker. When the card's missing
-     *  set empties, the Approve button re-enables and the banner hides.
-     *
-     *  The actual DB state is already up to date (the POST happens in the
-     *  config widget's save handler), so re-approving goes through the
-     *  existing ``_resolve_secrets`` check without any new state to sync.
+    /** Called when ``credential-added`` fires. Walks every open interrupt
+     *  card and clears the warning markers for the just-added credential —
+     *  the warning banner and the pill's missing-class need to disappear
+     *  once the user resolves the gap. The Approve button is not gated on
+     *  credentials; it stays clickable regardless.
      */
     private _onCredentialAdded(name: string): void {
         const cards = this._messagesDiv.querySelectorAll<HTMLElement>('.interrupt-card');
@@ -545,8 +547,6 @@ export class ChatWidget extends Widget {
             if (missingSet.size === 0) {
                 const banner = card.querySelector<HTMLElement>('.interrupt-missing-banner');
                 if (banner) banner.remove();
-                const approve = card.querySelector<HTMLButtonElement>('.interrupt-approve');
-                if (approve) approve.disabled = false;
             }
         });
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ postgres = [
     "langgraph-checkpoint-postgres>=3.0.4",
 ]
 sandbox = [
-    "daytona-sdk>=0.149.0",
+    "daytona-sdk>=0.166.0",
 ]
 vectorstore = [
     "langchain-chroma>=1.1.0",

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -297,23 +297,34 @@ def _validate_materializations(materializations: Any) -> str | None:
     return None
 
 
-async def _resolve_secrets(db, user_id: str, names: list[str]) -> tuple[dict[str, str] | None, str | None]:
-    """Decrypt every named secret for a user.
+async def _resolve_secrets(db, user_id: str, names: list[str]) -> tuple[dict[str, str], list[str], str | None]:
+    """Decrypt every named secret available in the user's store.
 
-    Returns ``(values, None)`` on success or ``(None, error_string)`` if any
-    name is missing from the user's store. Caller must have already
-    validated the materialization shape.
+    Missing names are treated as **optional**: they are returned in the
+    ``missing`` list and silently dropped from injection rather than
+    failing the call. The CLI/script is responsible for raising a clear
+    error if it actually requires a credential that wasn't injected. This
+    lets a single skill cover both public-anonymous and private-authenticated
+    workflows without splitting into two skills per source.
+
+    Returns ``(values, missing, error_string)``:
+      - ``values``: name -> decrypted value for every name that was present.
+      - ``missing``: names that were not in the user's store (can be empty).
+      - ``error_string``: only set when decryption itself fails for a
+        present-but-unreadable secret (a real error, not just absence).
     """
     values: dict[str, str] = {}
+    missing: list[str] = []
     for name in names:
         ct = await db.get_credential_ciphertext_by_name(user_id, name)
         if ct is None:
-            return None, f"credential {name!r} is not configured — add it in settings"
+            missing.append(name)
+            continue
         try:
             values[name] = decrypt_value(ct)
         except Exception as e:  # pragma: no cover - decrypt should not fail in practice
-            return None, f"failed to decrypt credential {name!r}: {e}"
-    return values, None
+            return values, missing, f"failed to decrypt credential {name!r}: {e}"
+    return values, missing, None
 
 
 def _build_runtime_injection(
@@ -321,6 +332,15 @@ def _build_runtime_injection(
     secret_values: dict[str, str],
 ) -> tuple[dict[str, str], dict[str, str]]:
     """Turn validated materializations + decrypted values into env vars and files.
+
+    Names that are absent from ``secret_values`` (because the user did not
+    have that credential stored) are silently skipped:
+
+      - ``env_vars`` plans only set entries for names that resolved.
+      - ``file`` plans are dropped entirely if any of their referenced names
+        are missing — a partially-rendered netrc/credential file is worse
+        than no file at all (callers expecting a complete file would pass
+        broken auth to the underlying tool).
 
     Returns ``(env_vars, files)`` where ``env_vars`` is a flat dict for
     ``CodeRunParams.env`` and ``files`` is a dict of ``path -> content`` ready
@@ -332,8 +352,13 @@ def _build_runtime_injection(
     for m in materializations:
         if m["kind"] == "env_vars":
             for name in m["names"]:
-                env[name] = secret_values[name]
+                if name in secret_values:
+                    env[name] = secret_values[name]
         elif m["kind"] == "file":
+            # Skip the entire file if any referenced name is unresolved —
+            # don't write a half-templated credential file to the sandbox.
+            if not all(n in secret_values for n in m["names"]):
+                continue
             path = m["path"]
             rendered = substitute_placeholders(m["content"], secret_values)
             if path in files:
@@ -411,7 +436,7 @@ async def resolve_credentials_or_error(
             }
         )
 
-    secret_values, err = await _resolve_secrets(db, convo["user_id"], referenced_names)
+    secret_values, missing, err = await _resolve_secrets(db, convo["user_id"], referenced_names)
     if err:
         return Command(
             update={
@@ -424,6 +449,11 @@ async def resolve_credentials_or_error(
                 ]
             }
         )
+    # Missing names are intentionally non-fatal — see _resolve_secrets docstring.
+    # The CLI/script is responsible for reporting if a credential it needed
+    # wasn't injected. Logging the missing set helps debug "why didn't auth work".
+    if missing:
+        logger.info("Credential names not configured (skipped): %s", ", ".join(missing))
 
     env_vars, file_uploads = _build_runtime_injection(materializations, secret_values)
     redaction_list = list(secret_values.values())
@@ -537,7 +567,9 @@ def make_execute_python_code(db=None):
                     }
                 )
             user_id = convo["user_id"]
-            secret_values, err = await _resolve_secrets(db, user_id, referenced_names)
+            secret_values, missing, err = await _resolve_secrets(db, user_id, referenced_names)
+            if missing:
+                logger.info("Credential names not configured (skipped): %s", ", ".join(missing))
             if err:
                 return Command(
                     update={

--- a/src/rhiza_agents/agents/tools/skills.py
+++ b/src/rhiza_agents/agents/tools/skills.py
@@ -171,21 +171,25 @@ def _build_activation_response(skill_record: dict) -> str:
             "PEP 723 inline metadata so `uv run` resolves their dependencies."
         )
 
-    # Declared credential requirements (from metadata.openclaw.requires.env).
-    # Passing them explicitly to the agent makes the contract structural
-    # instead of something the LLM has to infer from prose in the skill body.
-    # The approval UI also flags missing names, but this tells the model
-    # which credentials to REQUEST in the first place.
+    # Declared credential names (from metadata.openclaw.requires.env). These
+    # are credentials the skill's scripts MAY use. The runtime treats them as
+    # optional: if the user has the credential stored, it gets injected into
+    # the sandbox; if not, it's silently skipped and the script/CLI is
+    # responsible for surfacing a clear error if it actually needed the
+    # credential. Always pass the full list so the runtime knows which names
+    # to plumb when available.
     if parsed.required_env:
         bullets = "\n".join(f"  - {n}" for n in parsed.required_env)
         parts.append(
             "\n\n---\n"
-            "This skill requires these credential names to run its scripts:\n"
+            "This skill MAY use these credentials (injected when set, "
+            "skipped when not):\n"
             f"{bullets}\n"
-            "Pass them to run_file's `credentials` argument as "
-            '`[{"kind": "env_vars", "names": [...]}]` when executing the bundled '
-            "scripts. If any are not available, stop and tell the user to add "
-            "them in settings; do not invent values."
+            "Pass the full list to run_file's `credentials` argument as "
+            '`[{"kind": "env_vars", "names": [...]}]` when executing the '
+            "bundled scripts. The script will fail with a clear message if it "
+            "needed a credential that wasn't injected — surface that message "
+            "to the user; do not invent values."
         )
 
     return "\n".join(parts)

--- a/src/rhiza_agents/routes/chat.py
+++ b/src/rhiza_agents/routes/chat.py
@@ -85,10 +85,12 @@ async def _enrich_interrupt_payload(intr_data, db, user_id: str) -> dict:
     attached so the frontend can render a single warning without re-walking.
 
     Returns a plain dict (the normalized shape — the original ``intr_data``
-    may be a Pydantic model or langgraph ``Interrupt``). On any DB error we
-    degrade to returning the payload with empty ``missing_credentials``;
-    the existing post-approval ``_resolve_secrets`` check is the real gate,
-    this UI enrichment is purely informational.
+    may be a Pydantic model or langgraph ``Interrupt``). The frontend uses
+    this purely as a warning ("these names won't be injected because you
+    haven't set them") and does not gate the Approve button on it. Missing
+    names are silently dropped from the materialization at execution time,
+    and the underlying CLI/script is responsible for surfacing a clear error
+    if it actually needed a credential that wasn't injected.
     """
     # Normalize to a plain dict. HumanInTheLoopMiddleware passes us a dict
     # already but subclasses might not.

--- a/tests/test_sandbox_credentials.py
+++ b/tests/test_sandbox_credentials.py
@@ -176,6 +176,57 @@ def test_build_runtime_injection_concatenates_same_path():
     assert files == {"~/.netrc": "machine a login alice password p1\nmachine b login bob password p2\n"}
 
 
+def test_build_runtime_injection_skips_missing_env_vars():
+    """Names absent from the secret store are silently dropped from the env
+    dict (not raised, not substituted with placeholders). Lets a single skill
+    list both required and optional credentials and have it Just Work for the
+    user who only configured the required ones."""
+    env, files = _build_runtime_injection(
+        [{"kind": "env_vars", "names": ["NASA_USER", "NASA_PASS", "OPTIONAL_KEY"]}],
+        {"NASA_USER": "alice", "NASA_PASS": "hunter2"},
+    )
+    assert env == {"NASA_USER": "alice", "NASA_PASS": "hunter2"}
+    assert "OPTIONAL_KEY" not in env
+    assert files == {}
+
+
+def test_build_runtime_injection_drops_partially_resolvable_file():
+    """A file materialization is dropped entirely if any of its referenced
+    names is missing — a partially-rendered netrc is worse than no netrc."""
+    env, files = _build_runtime_injection(
+        [
+            {
+                "kind": "file",
+                "path": "~/.netrc",
+                "names": ["U", "P"],
+                "content": "machine x login {U} password {P}\n",
+            }
+        ],
+        {"U": "alice"},  # P is missing
+    )
+    assert env == {}
+    assert files == {}
+
+
+def test_build_runtime_injection_keeps_other_materializations_when_one_drops():
+    """Dropping an unresolvable file does not affect other materializations."""
+    env, files = _build_runtime_injection(
+        [
+            {"kind": "env_vars", "names": ["A"]},
+            {
+                "kind": "file",
+                "path": "~/.netrc",
+                "names": ["U", "P"],
+                "content": "machine x login {U} password {P}\n",
+            },
+            {"kind": "env_vars", "names": ["B"]},
+        ],
+        {"A": "1", "B": "2"},  # U and P missing
+    )
+    assert env == {"A": "1", "B": "2"}
+    assert files == {}
+
+
 def test_daytona_sandbox_resources_unset(monkeypatch):
     monkeypatch.delenv("DAYTONA_SANDBOX_DISK_GIB", raising=False)
     assert _daytona_sandbox_resources_from_env() is None

--- a/tests/test_skills_activation.py
+++ b/tests/test_skills_activation.py
@@ -301,18 +301,24 @@ def test_parse_skill_md_openclaw_does_not_corrupt_stringified_metadata():
 # -- Activation hint for declared credentials ----------------------------
 
 
-def test_activation_response_includes_required_env_hint():
+def test_activation_response_includes_optional_env_hint():
     resp = _build_activation_response({"id": "sk", "skill_md": _OPENCLAW_MD})
-    assert "This skill requires these credential names" in resp
+    # Declared credentials are optional at runtime; the script/CLI is
+    # responsible for deciding what's actually required for a given
+    # invocation. The activation hint must communicate this to the agent.
+    assert "MAY use these credentials" in resp
     assert "MATON_API_KEY" in resp
     assert "TAHMO_USERNAME" in resp
-    # The instruction nudges the agent toward the right tool argument shape.
+    # The instruction still nudges the agent toward the right tool argument shape.
     assert "env_vars" in resp
+    # And explains that downstream errors are the script's responsibility,
+    # not the agent's to pre-validate.
+    assert "credential that wasn't injected" in resp
 
 
 def test_activation_response_omits_credential_hint_when_empty():
     resp = _build_activation_response(_record())
-    assert "This skill requires these credential names" not in resp
+    assert "MAY use these credentials" not in resp
 
 
 # -- requires_sandbox uses parsed.required_bins --------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -614,7 +614,7 @@ asyncpg = [
 
 [[package]]
 name = "daytona-api-client"
-version = "0.149.0"
+version = "0.169.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -622,14 +622,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/19/4123c4ae70addd8eb9ccfcd79d8cee919990d66fa9c484892235e5293343/daytona_api_client-0.149.0.tar.gz", hash = "sha256:d09da11357dbb91f2e555cd2ffc75f680bbb8a7b33d3c19b9e4d03f3baf99d63", size = 140937, upload-time = "2026-03-05T09:48:09.593Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/40/e9a68fce710f8141f892630b083cbfce01b6b172e48f52496f975b1bcf68/daytona_api_client-0.169.0.tar.gz", hash = "sha256:876aead483bd217667ae7c3e32677b413c75197bfa99be8f11ce51ccfa3be3df", size = 148544, upload-time = "2026-04-24T08:16:12.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/af/9d3f425dccfffd8a67dc422237abf1dd2a45474db022d68db8534235719f/daytona_api_client-0.149.0-py3-none-any.whl", hash = "sha256:d022cacd8b19be731bf188548d0b91f4897dec4320b30edae91438a39f22f081", size = 394608, upload-time = "2026-03-05T09:48:07.175Z" },
+    { url = "https://files.pythonhosted.org/packages/50/7b/4809b6b298195942484b4c495bf569c9d1c80cd252e9d3d16dc0f6f65ff6/daytona_api_client-0.169.0-py3-none-any.whl", hash = "sha256:f69d390b7f3b49dd2696fc6724ac3adeddac82720b4dc7a062a13868dfbe5d5c", size = 409335, upload-time = "2026-04-24T08:16:11.166Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.149.0"
+version = "0.169.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -639,14 +639,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/5e/184f5267d8f4dd79daffd7b06ba08d4aa15e016e4e9dc3bd286afa1752eb/daytona_api_client_async-0.149.0.tar.gz", hash = "sha256:c6103bc9c1f54c4f20a97058b2d96a6044aafb485a0fef97c8d2a3b5ffe1eb48", size = 141071, upload-time = "2026-03-05T09:48:35.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/66/b781e326d793d0b7866f9eb0ee9c33d51ac603ce29a3a5e60b03df2d02a4/daytona_api_client_async-0.169.0.tar.gz", hash = "sha256:d3ce3039b3edf13344a0da5745fb9d698ef8f52fbc51644d81c979b8829a2181", size = 148764, upload-time = "2026-04-24T08:16:47.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/c5/41a84112a124d6651c52bc4ae94cf6f0e2c6f9bf5a2ce102229cad395f5d/daytona_api_client_async-0.149.0-py3-none-any.whl", hash = "sha256:765c79351bd7127ef2876282276df95256b0594ca81a446cb188a54ac439b484", size = 397598, upload-time = "2026-03-05T09:48:33.156Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/2e0809fd85a5ab8245e6852503195b40bfd1a9b4ba1cc5e2329ff94b944f/daytona_api_client_async-0.169.0-py3-none-any.whl", hash = "sha256:72f50e94104880c0280b3f1bc7c254f704dfd45dedf442fa2b2d7a6288e95016", size = 412424, upload-time = "2026-04-24T08:16:45.115Z" },
 ]
 
 [[package]]
 name = "daytona-sdk"
-version = "0.149.0"
+version = "0.169.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -655,26 +655,27 @@ dependencies = [
     { name = "daytona-toolbox-api-client" },
     { name = "daytona-toolbox-api-client-async" },
     { name = "deprecated" },
-    { name = "environs" },
     { name = "httpx" },
-    { name = "multipart" },
     { name = "obstore" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-aiohttp-client" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "toml" },
+    { name = "urllib3" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/99/56eb2c6df931b95c40ebcba27192608bfe072156ec29a9822c69e14f6c32/daytona_sdk-0.149.0.tar.gz", hash = "sha256:3a4370746f2617c366b55ef7e20867f42389dd126fd503ab2c6a2503e37e1524", size = 123595, upload-time = "2026-03-05T09:49:13.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/d7/bc5db302576609dd6d90ce4346c74609a0b6edb76eb441930a729bf9f148/daytona_sdk-0.169.0.tar.gz", hash = "sha256:43d5acd8b6eddeedd7441da7799e2eb531b651d999226040ba84eb7ac6d0b962", size = 122830, upload-time = "2026-04-24T08:17:27.982Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/d6/9ffa5fce326180af460fa957707382df7456555b4ea10d204f4c9529e471/daytona_sdk-0.149.0-py3-none-any.whl", hash = "sha256:e3bee6cf8f964af3657dbf59f255ef32f1031d84f9c69b5d266e555be250108c", size = 153853, upload-time = "2026-03-05T09:49:11.86Z" },
+    { url = "https://files.pythonhosted.org/packages/32/64/c7162fe471e9674fca6d57432c1d00300baafe8a962819d2c9a875de12b1/daytona_sdk-0.169.0-py3-none-any.whl", hash = "sha256:e9abc16fa8b56b272471da576d4af82593e286834ab2d834bc614a6a741123b9", size = 152349, upload-time = "2026-04-24T08:17:26.009Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.149.0"
+version = "0.169.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -682,14 +683,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/52/d66d921ba754446f4a670248b27b5c25fb2152534007473a01301d055335/daytona_toolbox_api_client-0.149.0.tar.gz", hash = "sha256:46cb39f6d93d98a9282c9d470ead478c41653f11b9bd8a8a2df9413c7a570165", size = 64769, upload-time = "2026-03-05T09:48:08.354Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/18/8ae3c031d1ea27bd02a88def50c0aa3ba21c7a77e5820cc31fed40cad28f/daytona_toolbox_api_client-0.169.0.tar.gz", hash = "sha256:352fb946a504858dc551584ed557a60eb2c5c6e339ae8c5ff6b80a820f99439b", size = 69737, upload-time = "2026-04-24T08:16:20.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/28/afe8b00ff89a10305b0be04cd44dc41c691f6ee0a0216af75500f71e0700/daytona_toolbox_api_client-0.149.0-py3-none-any.whl", hash = "sha256:e2715bdbbda0faf4436549eb4b0fd7c2464e1ac6eca2239589e643225ce9f576", size = 174401, upload-time = "2026-03-05T09:48:06.303Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/92/357e1fb494d8b04d99f999bd0048a2d3cf12b3562c3b8974b7b7bef90e7b/daytona_toolbox_api_client-0.169.0-py3-none-any.whl", hash = "sha256:b800986b08d903e0252ab8a2d346f238e405de7030ff82b82014185ddc3e15a9", size = 187620, upload-time = "2026-04-24T08:16:18.886Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.149.0"
+version = "0.169.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -699,9 +700,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/74/2b9238822cf097ee5db11d801a0764752b3414e3071b932345ff508e0948/daytona_toolbox_api_client_async-0.149.0.tar.gz", hash = "sha256:725da4ec856451aa0848f6ba7b48d5c1206b0ebf225d880731634a6fe534eb3d", size = 61845, upload-time = "2026-03-05T09:48:11.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/ee/40139eaf32d31f0e7e8662841d08026fce4e05935c18532f44dd9e858552/daytona_toolbox_api_client_async-0.169.0.tar.gz", hash = "sha256:0c78be8c4f8acee54f6ec1c7f94a0d128f8a03930122dc8d6145a024592e86b2", size = 66812, upload-time = "2026-04-24T08:16:36.385Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/2d/3c861619572e70fb87205902ba30a0bb908f27267bd0756cdd5c1fadde2d/daytona_toolbox_api_client_async-0.149.0-py3-none-any.whl", hash = "sha256:d6b1f36a6d1fa1e5687283a4a8a6396b49dbb87eace1b263714f4be222013844", size = 175774, upload-time = "2026-03-05T09:48:09.397Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1a/748d844f7ba52190db9af447c501abf69402333e79857de2d9b972e001a4/daytona_toolbox_api_client_async-0.169.0-py3-none-any.whl", hash = "sha256:565cbdb56895c149b0782a1b165ba029cc5bc35309cc6586253eda54b3ac335c", size = 189045, upload-time = "2026-04-24T08:16:35.185Z" },
 ]
 
 [[package]]
@@ -750,19 +751,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
-]
-
-[[package]]
-name = "environs"
-version = "14.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "marshmallow" },
-    { name = "python-dotenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/c7/94f97e6e74482a50b5fc798856b6cc06e8d072ab05a0b74cb5d87bd0d065/environs-14.6.0.tar.gz", hash = "sha256:ed2767588deb503209ffe4dd9bb2b39311c2e4e7e27ce2c64bf62ca83328d068", size = 35563, upload-time = "2026-02-20T04:02:08.869Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/a8/c070e1340636acb38d4e6a7e45c46d168a462b48b9b3257e14ca0e5af79b/environs-14.6.0-py3-none-any.whl", hash = "sha256:f8fb3d6c6a55872b0c6db077a28f5a8c7b8984b7c32029613d44cef95cfc0812", size = 17205, upload-time = "2026-02-20T04:02:07.299Z" },
 ]
 
 [[package]]
@@ -1624,15 +1612,6 @@ wheels = [
 ]
 
 [[package]]
-name = "marshmallow"
-version = "4.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/03/261af5efb3d3ce0e2db3fd1e11dc5a96b74a4fb76e488da1c845a8f12345/marshmallow-4.2.2.tar.gz", hash = "sha256:ba40340683a2d1c15103647994ff2f6bc2c8c80da01904cbe5d96ee4baa78d9f", size = 221404, upload-time = "2026-02-04T15:47:03.401Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/70/bb89f807a6a6704bdc4d6f850d5d32954f6c1965e3248e31455defdf2f30/marshmallow-4.2.2-py3-none-any.whl", hash = "sha256:084a9466111b7ec7183ca3a65aed758739af919fedc5ebdab60fb39d6b4dc121", size = 48454, upload-time = "2026-02-04T15:47:02.013Z" },
-]
-
-[[package]]
 name = "mcp"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1854,15 +1833,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
-]
-
-[[package]]
-name = "multipart"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/d6/9c4f366d6f9bb8f8fb5eae3acac471335c39510c42b537fd515213d7d8c3/multipart-1.3.1.tar.gz", hash = "sha256:211d7cfc1a7a43e75c4d24ee0e8e0f4f61d522f1a21575303ae85333dea687bf", size = 38929, upload-time = "2026-02-27T10:17:13.7Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/ed/e1f03200ee1f0bf4a2b9b72709afefbf5319b68df654e0b84b35c65613ee/multipart-1.3.1-py3-none-any.whl", hash = "sha256:a82b59e1befe74d3d30b3d3f70efd5a2eba4d938f845dcff9faace968888ff29", size = 15061, upload-time = "2026-02-27T10:17:11.943Z" },
 ]
 
 [[package]]
@@ -2983,7 +2953,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "databases", extras = ["aiosqlite"] },
     { name = "databases", extras = ["asyncpg"], marker = "extra == 'postgres'" },
-    { name = "daytona-sdk", marker = "extra == 'sandbox'", specifier = ">=0.149.0" },
+    { name = "daytona-sdk", marker = "extra == 'sandbox'", specifier = ">=0.166.0" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "httpx-sse" },


### PR DESCRIPTION
Credentials are now optional and dont block running a skill with missing credentials. 

this allows a skill with optional credentials to still be used. Skills where credentials are strictly required should return a nice error message explaining that the env var was not set and is required so the agent can figure out what went wrong.