### PR TITLE
sandbox: persistent volumes, non-root agent, skill containment

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -64,3 +64,14 @@ env:
   # DATABASE_URL is set automatically to point at the PVC-mounted SQLite file
   # CHECKPOINT_DB_PATH is set automatically to point at the PVC-mounted checkpoints file
   # CHROMA_PERSIST_DIR is set automatically to point at the PVC-mounted chroma directory
+  # Persistent storage for sandbox files. The homes volume is mounted at
+  # DAYTONA_HOMES_MOUNT_PATH (default /workspace) with a per-conversation
+  # subpath; the data volume is mounted at DAYTONA_DATA_MOUNT_PATH (default
+  # /data) and shared across conversations. Volumes must be created in
+  # Daytona before the app uses them — names are looked up with
+  # create=False, so a missing volume disables that mount with a warning.
+  # Leave both volume-name vars empty to disable persistent storage.
+  DAYTONA_HOMES_VOLUME: ""
+  DAYTONA_HOMES_MOUNT_PATH: ""
+  DAYTONA_DATA_VOLUME: ""
+  DAYTONA_DATA_MOUNT_PATH: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,17 @@ services:
       DAYTONA_PROXY_URL: ${DAYTONA_PROXY_URL:-}
       # Optional: sandbox root disk in GiB (Daytona API). Unset = platform default.
       DAYTONA_SANDBOX_DISK_GIB: ${DAYTONA_SANDBOX_DISK_GIB:-}
+      # Persistent storage for sandbox files. The homes volume is mounted
+      # at DAYTONA_HOMES_MOUNT_PATH (default /workspace) with a per-thread
+      # subpath; the data volume is mounted at DAYTONA_DATA_MOUNT_PATH
+      # (default /data) and shared across conversations. Volumes must be
+      # pre-created in Daytona — names are looked up with create=False, so
+      # a missing volume disables that mount with a warning. Leave the
+      # volume-name vars empty to disable persistent storage.
+      DAYTONA_HOMES_VOLUME: ${DAYTONA_HOMES_VOLUME:-}
+      DAYTONA_HOMES_MOUNT_PATH: ${DAYTONA_HOMES_MOUNT_PATH:-}
+      DAYTONA_DATA_VOLUME: ${DAYTONA_DATA_VOLUME:-}
+      DAYTONA_DATA_MOUNT_PATH: ${DAYTONA_DATA_MOUNT_PATH:-}
       CHROMA_PERSIST_DIR: /data/chroma
       CHAT_EVENT_LOGGING: "true"
       WATCHFILES_FORCE_POLLING: "true"

--- a/frontend/src/lib/dialog.ts
+++ b/frontend/src/lib/dialog.ts
@@ -1,0 +1,134 @@
+/**
+ * Promise-returning modal dialog helpers built on the native
+ * <dialog> element. Used in place of window.confirm / window.alert,
+ * which are blocking modals the browser owns and which break browser
+ * automation (Playwright/Cypress/Selenium have to register a `dialog`
+ * handler ahead of time, and if you forget the test hangs). The
+ * native <dialog> element is just a DOM node — automation tools see
+ * its buttons and can click them like anything else.
+ */
+
+interface ConfirmOptions {
+    title?: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    /** Style the confirm button as destructive (red). Default false. */
+    destructive?: boolean;
+}
+
+interface AlertOptions {
+    title?: string;
+    message: string;
+    confirmLabel?: string;
+}
+
+/** Show a modal yes/no confirmation. Resolves to true if the user
+ * clicks confirm, false if they cancel or dismiss. */
+export function confirmDialog(opts: ConfirmOptions): Promise<boolean> {
+    return new Promise((resolve) => {
+        const dlg = _buildDialog({
+            title: opts.title,
+            message: opts.message,
+            buttons: [
+                {
+                    label: opts.cancelLabel ?? 'Cancel',
+                    role: 'cancel',
+                    onClick: () => resolve(false),
+                },
+                {
+                    label: opts.confirmLabel ?? 'OK',
+                    role: 'confirm',
+                    destructive: opts.destructive ?? false,
+                    onClick: () => resolve(true),
+                },
+            ],
+            onDismiss: () => resolve(false),
+        });
+        document.body.appendChild(dlg);
+        dlg.showModal();
+    });
+}
+
+/** Show a modal informational/error message with one OK button.
+ * Resolves when dismissed. */
+export function alertDialog(opts: AlertOptions): Promise<void> {
+    return new Promise((resolve) => {
+        const dlg = _buildDialog({
+            title: opts.title,
+            message: opts.message,
+            buttons: [
+                {
+                    label: opts.confirmLabel ?? 'OK',
+                    role: 'confirm',
+                    onClick: () => resolve(),
+                },
+            ],
+            onDismiss: () => resolve(),
+        });
+        document.body.appendChild(dlg);
+        dlg.showModal();
+    });
+}
+
+interface _ButtonSpec {
+    label: string;
+    role: 'confirm' | 'cancel';
+    destructive?: boolean;
+    onClick: () => void;
+}
+
+interface _DialogSpec {
+    title?: string;
+    message: string;
+    buttons: _ButtonSpec[];
+    onDismiss: () => void;
+}
+
+function _buildDialog(spec: _DialogSpec): HTMLDialogElement {
+    const dlg = document.createElement('dialog');
+    dlg.className = 'app-dialog';
+    // Cancel via Esc / backdrop click resolves with the dismiss action.
+    let resolved = false;
+    dlg.addEventListener('close', () => {
+        if (!resolved) {
+            resolved = true;
+            spec.onDismiss();
+        }
+        dlg.remove();
+    });
+
+    if (spec.title) {
+        const h = document.createElement('h3');
+        h.className = 'app-dialog-title';
+        h.textContent = spec.title;
+        dlg.appendChild(h);
+    }
+
+    const body = document.createElement('p');
+    body.className = 'app-dialog-message';
+    body.textContent = spec.message;
+    dlg.appendChild(body);
+
+    const actions = document.createElement('div');
+    actions.className = 'app-dialog-actions';
+
+    for (const btn of spec.buttons) {
+        const el = document.createElement('button');
+        el.type = 'button';
+        el.textContent = btn.label;
+        el.name = btn.role;  // automation can locator('dialog button[name="confirm"]')
+        el.className = `app-dialog-btn app-dialog-btn-${btn.role}`;
+        if (btn.destructive) el.classList.add('app-dialog-btn-destructive');
+        el.addEventListener('click', () => {
+            if (resolved) return;
+            resolved = true;
+            btn.onClick();
+            dlg.close();
+        });
+        actions.appendChild(el);
+    }
+
+    dlg.appendChild(actions);
+    return dlg;
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -55,6 +55,18 @@ body { height: 100vh; margin: 0; }
 .chat-widget .input-area button:hover { opacity: 0.9; }
 .chat-widget .input-area button:disabled { opacity: 0.5; cursor: not-allowed; }
 .activity-widget .activity-content { flex: 1; overflow-y: auto; padding: 0.5rem; }
+.files-widget .files-scope-toggle {
+    display: flex; gap: 0.25rem; padding: 0.5rem; border-bottom: 1px solid var(--jp-border-color1);
+    background: var(--jp-layout-color1);
+}
+.files-widget .files-scope-btn {
+    flex: 1; padding: 0.25rem 0.5rem; background: transparent; color: var(--jp-ui-font-color2);
+    border: 1px solid var(--jp-border-color1); border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+}
+.files-widget .files-scope-btn:hover { background: var(--jp-layout-color2); }
+.files-widget .files-scope-btn.active {
+    background: var(--jp-brand-color1); color: white; border-color: var(--jp-brand-color1);
+}
 .files-widget .files-list { flex: 1; overflow-y: auto; padding: 0.5rem; }
 .files-widget .file-viewer { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
 .file-viewer.hidden { display: none; }
@@ -138,6 +150,8 @@ body { height: 100vh; margin: 0; }
 .file-source { font-size: 0.6rem; padding: 1px 5px; border-radius: 3px; text-transform: uppercase; font-weight: 600; }
 .file-source-agent { background: rgba(33,150,243,0.2); color: var(--jp-brand-color2); }
 .file-source-output { background: rgba(76,175,80,0.2); color: var(--jp-accent-color2); }
+.file-source-data { background: rgba(255,152,0,0.2); color: var(--md-orange-300, #ffb74d); }
+.file-source-workspace { background: rgba(156,39,176,0.18); color: var(--md-purple-300, #ba68c8); }
 .files-empty { padding: 2rem; text-align: center; color: var(--jp-ui-font-color3); }
 .file-viewer-header { padding: 0.5rem; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--jp-border-color1); }
 .file-viewer-path { font-family: var(--jp-code-font-family); font-size: 0.8rem; color: var(--jp-ui-font-color2); }
@@ -167,11 +181,23 @@ body { height: 100vh; margin: 0; }
 
 /* Conversations */
 .conversation-item {
-    display: block; padding: 0.5rem; text-decoration: none; color: var(--jp-ui-font-color2);
-    border-radius: 4px; font-size: 0.9rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    display: flex; align-items: center; padding: 0.25rem 0.25rem 0.25rem 0.5rem;
+    color: var(--jp-ui-font-color2); border-radius: 4px; font-size: 0.9rem;
 }
 .conversation-item:hover { background: var(--jp-layout-color2); color: var(--jp-ui-font-color1); }
 .conversation-item.active { background: var(--jp-layout-color2); color: var(--jp-ui-font-color0); font-weight: 500; }
+.conversation-item-link {
+    flex: 1; min-width: 0; padding: 0.25rem 0; text-decoration: none; color: inherit;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.conversation-delete-btn {
+    flex: 0 0 auto; margin-left: 0.25rem; width: 1.25rem; height: 1.25rem;
+    padding: 0; background: transparent; color: var(--jp-ui-font-color3); border: none;
+    border-radius: 4px; cursor: pointer; opacity: 0; line-height: 1;
+    font-size: 1.1rem; transition: opacity 0.1s, background 0.1s, color 0.1s;
+}
+.conversation-item:hover .conversation-delete-btn { opacity: 1; }
+.conversation-delete-btn:hover { background: var(--md-red-500, #e53935); color: white; opacity: 1; }
 .sidebar-header { padding: 0.5rem; border-bottom: 1px solid var(--jp-border-color1); }
 .new-chat-btn {
     width: 100%; padding: 0.5rem; background: var(--jp-brand-color1); color: white;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -198,6 +198,60 @@ body { height: 100vh; margin: 0; }
 }
 .conversation-item:hover .conversation-delete-btn { opacity: 1; }
 .conversation-delete-btn:hover { background: var(--md-red-500, #e53935); color: white; opacity: 1; }
+
+/* Modal dialogs (lib/dialog.ts) — replaces window.confirm/alert so the
+ * delete-conversation flow is reachable by browser automation. */
+.app-dialog {
+    border: 1px solid var(--jp-border-color1);
+    border-radius: 6px;
+    padding: 1rem 1.25rem;
+    min-width: 320px;
+    max-width: 480px;
+    background: var(--jp-layout-color1);
+    color: var(--jp-ui-font-color0);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+}
+.app-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.45);
+}
+.app-dialog-title {
+    margin: 0 0 0.5rem 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
+.app-dialog-message {
+    margin: 0 0 1rem 0;
+    font-size: 0.9rem;
+    line-height: 1.4;
+    color: var(--jp-ui-font-color1);
+}
+.app-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+.app-dialog-btn {
+    padding: 0.4rem 0.9rem;
+    border-radius: 4px;
+    border: 1px solid var(--jp-border-color1);
+    background: var(--jp-layout-color2);
+    color: var(--jp-ui-font-color0);
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+.app-dialog-btn:hover { background: var(--jp-layout-color3); }
+.app-dialog-btn-confirm {
+    background: var(--jp-brand-color1);
+    color: white;
+    border-color: var(--jp-brand-color1);
+}
+.app-dialog-btn-confirm:hover { background: var(--jp-brand-color0); }
+.app-dialog-btn-destructive {
+    background: var(--md-red-500, #e53935);
+    color: white;
+    border-color: var(--md-red-500, #e53935);
+}
+.app-dialog-btn-destructive:hover { background: var(--md-red-700, #c62828); }
 .sidebar-header { padding: 0.5rem; border-bottom: 1px solid var(--jp-border-color1); }
 .new-chat-btn {
     width: 100%; padding: 0.5rem; background: var(--jp-brand-color1); color: white;

--- a/frontend/src/widgets/conversations.ts
+++ b/frontend/src/widgets/conversations.ts
@@ -1,5 +1,7 @@
 import { Widget } from '@lumino/widgets';
 
+import { alertDialog, confirmDialog } from '../lib/dialog';
+
 export interface ConversationData {
     id: string;
     title: string | null;
@@ -97,16 +99,25 @@ export class ConversationListWidget extends Widget {
 
     private async _handleDelete(conv: ConversationData): Promise<void> {
         const title = conv.title || 'this conversation';
-        const ok = window.confirm(
-            `Delete "${title}"?\n\nThis removes the conversation, its messages, and any files saved on its workspace volume. This cannot be undone.`,
-        );
+        const ok = await confirmDialog({
+            title: 'Delete conversation?',
+            message:
+                `Delete "${title}"? This removes the conversation, its messages, ` +
+                'and any files saved on its workspace volume. This cannot be undone.',
+            confirmLabel: 'Delete',
+            cancelLabel: 'Cancel',
+            destructive: true,
+        });
         if (!ok) return;
 
         let response: Response;
         try {
             response = await fetch(`/api/conversations/${conv.id}`, { method: 'DELETE' });
         } catch (e) {
-            window.alert(`Failed to delete: ${(e as Error).message}`);
+            await alertDialog({
+                title: 'Delete failed',
+                message: `Failed to delete: ${(e as Error).message}`,
+            });
             return;
         }
 
@@ -118,7 +129,10 @@ export class ConversationListWidget extends Widget {
             } catch {
                 // ignore JSON parse failure; fall back to status text
             }
-            window.alert(`Failed to delete: ${message}`);
+            await alertDialog({
+                title: 'Delete failed',
+                message: `Failed to delete: ${message}`,
+            });
             return;
         }
 

--- a/frontend/src/widgets/conversations.ts
+++ b/frontend/src/widgets/conversations.ts
@@ -13,10 +13,16 @@ interface ConversationListOptions {
 
 /**
  * Sidebar widget showing conversation list, new chat button, and user info.
+ *
+ * Each row carries a delete affordance. The sidebar lists only the
+ * current user's own conversations (server filters by user_id), so the
+ * delete request is always against an owned conversation; the backend
+ * additionally enforces ownership and returns 403/404 on a mismatch.
  */
 export class ConversationListWidget extends Widget {
     private _conversations: ConversationData[];
     private _currentId: string;
+    private _nav: HTMLElement | null = null;
 
     constructor(options: ConversationListOptions) {
         super();
@@ -46,18 +52,83 @@ export class ConversationListWidget extends Widget {
         node.appendChild(header);
 
         // Conversation list
-        const nav = document.createElement('nav');
-        nav.className = 'conversations';
+        this._nav = document.createElement('nav');
+        this._nav.className = 'conversations';
+        this._renderList();
+        node.appendChild(this._nav);
+    }
+
+    private _renderList(): void {
+        if (!this._nav) return;
+        this._nav.innerHTML = '';
         for (const conv of this._conversations) {
-            const a = document.createElement('a');
-            a.href = `/c/${conv.id}`;
-            a.className = 'conversation-item';
-            if (conv.id === this._currentId) {
-                a.classList.add('active');
-            }
-            a.textContent = conv.title || 'New conversation';
-            nav.appendChild(a);
+            this._nav.appendChild(this._buildRow(conv));
         }
-        node.appendChild(nav);
+    }
+
+    private _buildRow(conv: ConversationData): HTMLElement {
+        const row = document.createElement('div');
+        row.className = 'conversation-item';
+        row.dataset.conversationId = conv.id;
+        if (conv.id === this._currentId) {
+            row.classList.add('active');
+        }
+
+        const link = document.createElement('a');
+        link.href = `/c/${conv.id}`;
+        link.className = 'conversation-item-link';
+        link.textContent = conv.title || 'New conversation';
+        row.appendChild(link);
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'conversation-delete-btn';
+        deleteBtn.title = 'Delete this conversation';
+        deleteBtn.setAttribute('aria-label', 'Delete conversation');
+        deleteBtn.textContent = '×';
+        deleteBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            void this._handleDelete(conv);
+        });
+        row.appendChild(deleteBtn);
+
+        return row;
+    }
+
+    private async _handleDelete(conv: ConversationData): Promise<void> {
+        const title = conv.title || 'this conversation';
+        const ok = window.confirm(
+            `Delete "${title}"?\n\nThis removes the conversation, its messages, and any files saved on its workspace volume. This cannot be undone.`,
+        );
+        if (!ok) return;
+
+        let response: Response;
+        try {
+            response = await fetch(`/api/conversations/${conv.id}`, { method: 'DELETE' });
+        } catch (e) {
+            window.alert(`Failed to delete: ${(e as Error).message}`);
+            return;
+        }
+
+        if (!response.ok) {
+            let message = `${response.status} ${response.statusText}`;
+            try {
+                const data = await response.json();
+                if (data?.detail) message = data.detail;
+            } catch {
+                // ignore JSON parse failure; fall back to status text
+            }
+            window.alert(`Failed to delete: ${message}`);
+            return;
+        }
+
+        // Remove from local list and re-render
+        this._conversations = this._conversations.filter((c) => c.id !== conv.id);
+        this._renderList();
+
+        // If the deleted conversation is the one being viewed, navigate home.
+        if (conv.id === this._currentId) {
+            window.location.href = '/';
+        }
     }
 }

--- a/frontend/src/widgets/conversations.ts
+++ b/frontend/src/widgets/conversations.ts
@@ -25,6 +25,10 @@ export class ConversationListWidget extends Widget {
     private _conversations: ConversationData[];
     private _currentId: string;
     private _nav: HTMLElement | null = null;
+    // Conversation IDs with a DELETE request in flight. Guards against a
+    // double-click firing a second DELETE (the first removes the row, the
+    // second 404s and pops a spurious "Delete failed" alert).
+    private _deleting = new Set<string>();
 
     constructor(options: ConversationListOptions) {
         super();
@@ -90,14 +94,18 @@ export class ConversationListWidget extends Widget {
         deleteBtn.addEventListener('click', (e) => {
             e.preventDefault();
             e.stopPropagation();
-            void this._handleDelete(conv);
+            void this._handleDelete(conv, deleteBtn);
         });
         row.appendChild(deleteBtn);
 
         return row;
     }
 
-    private async _handleDelete(conv: ConversationData): Promise<void> {
+    private async _handleDelete(conv: ConversationData, deleteBtn: HTMLButtonElement): Promise<void> {
+        // In-flight guard: a rapid second click (before the first request
+        // resolves and the row is removed) must not fire a second DELETE.
+        if (this._deleting.has(conv.id)) return;
+
         const title = conv.title || 'this conversation';
         const ok = await confirmDialog({
             title: 'Delete conversation?',
@@ -110,10 +118,18 @@ export class ConversationListWidget extends Widget {
         });
         if (!ok) return;
 
+        // Re-check after the await: the user could have confirmed a second
+        // dialog opened by a concurrent click before this one resolved.
+        if (this._deleting.has(conv.id)) return;
+        this._deleting.add(conv.id);
+        deleteBtn.disabled = true;
+
         let response: Response;
         try {
             response = await fetch(`/api/conversations/${conv.id}`, { method: 'DELETE' });
         } catch (e) {
+            this._deleting.delete(conv.id);
+            deleteBtn.disabled = false;
             await alertDialog({
                 title: 'Delete failed',
                 message: `Failed to delete: ${(e as Error).message}`,
@@ -122,6 +138,8 @@ export class ConversationListWidget extends Widget {
         }
 
         if (!response.ok) {
+            this._deleting.delete(conv.id);
+            deleteBtn.disabled = false;
             let message = `${response.status} ${response.statusText}`;
             try {
                 const data = await response.json();
@@ -136,7 +154,9 @@ export class ConversationListWidget extends Widget {
             return;
         }
 
-        // Remove from local list and re-render
+        // Remove from local list and re-render. The row (and its disabled
+        // button) is discarded; the _deleting entry is left set since the
+        // conversation is gone and cannot be deleted again.
         this._conversations = this._conversations.filter((c) => c.id !== conv.id);
         this._renderList();
 

--- a/frontend/src/widgets/conversations.ts
+++ b/frontend/src/widgets/conversations.ts
@@ -155,8 +155,10 @@ export class ConversationListWidget extends Widget {
         }
 
         // Remove from local list and re-render. The row (and its disabled
-        // button) is discarded; the _deleting entry is left set since the
-        // conversation is gone and cannot be deleted again.
+        // button) is discarded. Clear the in-flight guard entry too so the
+        // Set does not grow unbounded over a long-lived session; correctness
+        // does not rely on IDs never recurring.
+        this._deleting.delete(conv.id);
         this._conversations = this._conversations.filter((c) => c.id !== conv.id);
         this._renderList();
 

--- a/frontend/src/widgets/files.ts
+++ b/frontend/src/widgets/files.ts
@@ -13,8 +13,19 @@ interface FilesWidgetOptions {
     onOpenFile: (path: string, content: string, source: string, encoding?: string) => void;
 }
 
+type FileScope = 'session' | 'workspace';
+
 /**
  * Files panel widget — file list + file viewer with download/approve.
+ *
+ * Two scopes:
+ * - session: files this conversation tracked in state (offline-friendly,
+ *   rendered from LangGraph checkpoint data; works without an active sandbox)
+ * - workspace: live filesystem listing of /workspace (lazy-creates the
+ *   sandbox if none is running; cold-start latency is on this click)
+ *
+ * File contents are fetched on demand from the live sandbox; clicking a
+ * file in either scope triggers sandbox creation if needed.
  */
 export class FilesWidget extends Widget {
     private _getConversationId: () => string;
@@ -26,6 +37,10 @@ export class FilesWidget extends Widget {
     private _fileSources: Record<string, string> = {};
     private _fileEncodings: Record<string, string> = {};
     private _filesList!: HTMLDivElement;
+    private _scopeToggle!: HTMLDivElement;
+    private _sessionBtn!: HTMLButtonElement;
+    private _workspaceBtn!: HTMLButtonElement;
+    private _scope: FileScope = 'session';
 
     constructor(options: FilesWidgetOptions) {
         super();
@@ -45,9 +60,34 @@ export class FilesWidget extends Widget {
     private _buildDOM(): void {
         const node = this.node;
 
+        // Scope toggle: session (default) vs workspace (live FS)
+        this._scopeToggle = document.createElement('div');
+        this._scopeToggle.className = 'files-scope-toggle';
+        this._sessionBtn = document.createElement('button');
+        this._sessionBtn.className = 'files-scope-btn active';
+        this._sessionBtn.textContent = 'This session';
+        this._sessionBtn.title = 'Files this conversation has tracked (works offline)';
+        this._sessionBtn.addEventListener('click', () => this._setScope('session'));
+        this._workspaceBtn = document.createElement('button');
+        this._workspaceBtn.className = 'files-scope-btn';
+        this._workspaceBtn.textContent = 'All files';
+        this._workspaceBtn.title = 'Live listing of /workspace and /data — starts the sandbox if it is not already running';
+        this._workspaceBtn.addEventListener('click', () => this._setScope('workspace'));
+        this._scopeToggle.appendChild(this._sessionBtn);
+        this._scopeToggle.appendChild(this._workspaceBtn);
+        node.appendChild(this._scopeToggle);
+
         this._filesList = document.createElement('div');
         this._filesList.className = 'files-list';
         node.appendChild(this._filesList);
+    }
+
+    private _setScope(scope: FileScope): void {
+        if (scope === this._scope) return;
+        this._scope = scope;
+        this._sessionBtn.classList.toggle('active', scope === 'session');
+        this._workspaceBtn.classList.toggle('active', scope === 'workspace');
+        void this.loadFiles();
     }
 
     async loadFiles(): Promise<void> {
@@ -57,22 +97,33 @@ export class FilesWidget extends Widget {
             return;
         }
 
+        const url = `/api/conversations/${convId}/files?scope=${this._scope}`;
         try {
-            const response = await fetch(`/api/conversations/${convId}/files`);
+            if (this._scope === 'workspace') {
+                this._filesList.innerHTML = '<div class="files-empty">Loading workspace…</div>';
+            }
+            const response = await fetch(url);
             if (!response.ok) {
-                this._filesList.innerHTML = '<div class="files-empty">Failed to load files</div>';
+                this._filesList.innerHTML = `<div class="files-empty">Failed to load files (${response.status})</div>`;
                 return;
             }
 
             const files: any[] = await response.json();
-            const apiPaths = new Set(files.map((f: any) => f.path));
-            for (const [path, content] of Object.entries(this._streamedFiles)) {
-                if (!apiPaths.has(path)) {
-                    files.push({ path, size: new Blob([content || '']).size });
+            // Streamed-file overlay only applies in session view (the
+            // workspace view comes from the live filesystem already).
+            if (this._scope === 'session') {
+                const apiPaths = new Set(files.map((f: any) => f.path));
+                for (const [path, content] of Object.entries(this._streamedFiles)) {
+                    if (!apiPaths.has(path)) {
+                        files.push({ path, size: new Blob([content || '']).size, source: 'agent' });
+                    }
                 }
             }
             if (files.length === 0) {
-                this._filesList.innerHTML = '<div class="files-empty">No files yet</div>';
+                const empty = this._scope === 'workspace'
+                    ? 'Workspace is empty'
+                    : 'No files yet';
+                this._filesList.innerHTML = `<div class="files-empty">${empty}</div>`;
                 return;
             }
 
@@ -127,7 +178,18 @@ export class FilesWidget extends Widget {
 
         const sourceLabel = document.createElement('span');
         sourceLabel.className = `file-source file-source-${source}`;
-        sourceLabel.textContent = source === 'output' ? 'code-generated' : 'agent-generated';
+        // Source labels match the per-volume / per-tool conventions used
+        // server-side: "data" = file on the shared /data volume; "output"
+        // = produced by run_file (skill); "workspace" = file on the
+        // workspace volume in the live listing; "agent" = legacy / pre-
+        // zero-trust state-tracked. Anything else falls through to "agent".
+        const sourceText: Record<string, string> = {
+            data: 'shared data',
+            output: 'skill output',
+            workspace: 'workspace',
+            agent: 'agent-generated',
+        };
+        sourceLabel.textContent = sourceText[source] || sourceText.agent;
         item.appendChild(sourceLabel);
 
         const meta = document.createElement('span');

--- a/frontend/src/widgets/files.ts
+++ b/frontend/src/widgets/files.ts
@@ -111,7 +111,12 @@ export class FilesWidget extends Widget {
 
         const url = `/api/conversations/${convId}/files?scope=${requestedScope}`;
         try {
-            if (requestedScope === 'workspace') {
+            // Guard the placeholder write with the staleness check: a load
+            // that was superseded before it wrote the placeholder must not
+            // clobber a freshly-rendered list (a rapid toggle could
+            // otherwise leave "Loading workspace…" stuck after the newer
+            // load already rendered).
+            if (requestedScope === 'workspace' && !isStale()) {
                 this._filesList.innerHTML = '<div class="files-empty">Loading workspace…</div>';
             }
             const response = await fetch(url);

--- a/frontend/src/widgets/files.ts
+++ b/frontend/src/widgets/files.ts
@@ -41,6 +41,12 @@ export class FilesWidget extends Widget {
     private _sessionBtn!: HTMLButtonElement;
     private _workspaceBtn!: HTMLButtonElement;
     private _scope: FileScope = 'session';
+    // Monotonic token identifying the most recent loadFiles call. A slow
+    // response (e.g. the workspace listing that lazy-starts a sandbox) must
+    // not overwrite the list after the user toggled back to session and a
+    // newer load already ran. Each load captures the token at issue time
+    // and discards its result if a newer load has since started.
+    private _loadToken = 0;
 
     constructor(options: FilesWidgetOptions) {
         super();
@@ -91,27 +97,35 @@ export class FilesWidget extends Widget {
     }
 
     async loadFiles(): Promise<void> {
+        const token = ++this._loadToken;
+        const requestedScope = this._scope;
         const convId = this._getConversationId();
         if (!convId) {
             this._filesList.innerHTML = '<div class="files-empty">No conversation selected</div>';
             return;
         }
 
-        const url = `/api/conversations/${convId}/files?scope=${this._scope}`;
+        // Drop this response if a newer load has started since it was
+        // issued (the user toggled scope while this request was in flight).
+        const isStale = (): boolean => token !== this._loadToken;
+
+        const url = `/api/conversations/${convId}/files?scope=${requestedScope}`;
         try {
-            if (this._scope === 'workspace') {
+            if (requestedScope === 'workspace') {
                 this._filesList.innerHTML = '<div class="files-empty">Loading workspace…</div>';
             }
             const response = await fetch(url);
+            if (isStale()) return;
             if (!response.ok) {
                 this._filesList.innerHTML = `<div class="files-empty">Failed to load files (${response.status})</div>`;
                 return;
             }
 
             const files: any[] = await response.json();
+            if (isStale()) return;
             // Streamed-file overlay only applies in session view (the
             // workspace view comes from the live filesystem already).
-            if (this._scope === 'session') {
+            if (requestedScope === 'session') {
                 const apiPaths = new Set(files.map((f: any) => f.path));
                 for (const [path, content] of Object.entries(this._streamedFiles)) {
                     if (!apiPaths.has(path)) {
@@ -120,7 +134,7 @@ export class FilesWidget extends Widget {
                 }
             }
             if (files.length === 0) {
-                const empty = this._scope === 'workspace'
+                const empty = requestedScope === 'workspace'
                     ? 'Workspace is empty'
                     : 'No files yet';
                 this._filesList.innerHTML = `<div class="files-empty">${empty}</div>`;
@@ -136,6 +150,7 @@ export class FilesWidget extends Widget {
             }
         } catch (e) {
             console.error('Failed to load files:', e);
+            if (isStale()) return;
             this._filesList.innerHTML = '<div class="files-empty">Error loading files</div>';
         }
     }

--- a/src/rhiza_agents/agents/graph.py
+++ b/src/rhiza_agents/agents/graph.py
@@ -155,11 +155,17 @@ async def _resolve_tools(
             else:
                 logger.info("Skill %s not loaded, skipping", skill_id)
         elif tool_id == "sandbox:daytona":
-            from .tools.files import make_run_file, write_file
+            from .tools.files import make_run_file
             from .tools.sandbox import is_sandbox_available, make_execute_python_code
 
-            # File tools are always available (write to state, not sandbox)
-            tools.append(write_file)
+            # write_file is intentionally NOT registered under the
+            # zero-trust model — the agent has no direct file-write
+            # capability. Persistent files arrive via skills (run_file
+            # on /skills/<...> paths, executed as root) or via
+            # execute_python_code (HITL-approved arbitrary code,
+            # running as daytona). The implementation is preserved as
+            # a comment in tools/files.py for future revival.
+            # tools.append(write_file)
             if is_sandbox_available():
                 tools.append(make_execute_python_code(db=db))
                 tools.append(make_run_file(db=db))

--- a/src/rhiza_agents/agents/graph.py
+++ b/src/rhiza_agents/agents/graph.py
@@ -158,14 +158,6 @@ async def _resolve_tools(
             from .tools.files import make_run_file
             from .tools.sandbox import is_sandbox_available, make_execute_python_code
 
-            # write_file is intentionally NOT registered under the
-            # zero-trust model — the agent has no direct file-write
-            # capability. Persistent files arrive via skills (run_file
-            # on /skills/<...> paths, executed as root) or via
-            # execute_python_code (HITL-approved arbitrary code,
-            # running as daytona). The implementation is preserved as
-            # a comment in tools/files.py for future revival.
-            # tools.append(write_file)
             if is_sandbox_available():
                 tools.append(make_execute_python_code(db=db))
                 tools.append(make_run_file(db=db))

--- a/src/rhiza_agents/agents/registry.py
+++ b/src/rhiza_agents/agents/registry.py
@@ -38,63 +38,60 @@ If a tool call fails, retry with different parameters or explain the limitation.
 """
 
 _CODE_RUNNER_PROMPT = """\
-You are a code execution assistant. You help users write and run Python code \
-for data analysis, computation, and visualization.
+You are a code execution assistant. You help users analyze data and perform \
+computation by invoking trusted skills and, where appropriate, running short \
+exploratory Python.
 
-Do not output any text while you are writing or running code — just call tools. \
-Only produce a text response once you have the final results. Your text response \
-should present the results including the final code, output, and any explanations.
+Do not output any text while you are calling tools — just call tools. Only \
+produce a text response once you have the final results. Your text response \
+should present the results including any code you ran, output, and explanations.
 
-Write clean, well-commented code. When previous agents (e.g. research_assistant) \
-have provided information in the conversation, use that information as the basis \
-for your code. Do not re-research or re-gather data that has already been provided.
+When previous agents (e.g. research_assistant) have provided information in \
+the conversation, use that information as the basis for your code. Do not \
+re-research or re-gather data that has already been provided.
 
 ## Tool usage rules
 
-You have three code tools: write_file, run_file, and execute_python_code.
+You have two code tools: run_file and execute_python_code.
 
-**For any non-trivial code:** Always use write_file to save the script, then \
-run_file to execute it. This lets the user review the code before execution.
+**run_file** executes a script that has been installed by a skill. The path \
+must be of the form `/skills/<skill-name>/scripts/<filename>` — anything else \
+is rejected. Activate the skill (via its `skill_<name>` tool) first; the \
+activation message tells you which script paths are available. Skill scripts \
+run with elevated privileges so they can populate the shared `/data` cache.
 
-**CRITICAL: scripts MUST go through write_file → run_file. NEVER use \
-execute_python_code to run a script body — not by inlining the code, not by \
-calling exec(open(...)), not by importing the script, not by any other \
-workaround.** If you already wrote a file, you MUST use run_file to execute \
-it. The user reviews the written file; running different code via \
-execute_python_code bypasses that review and is a security violation.
+**execute_python_code** runs a short Python snippet you supply. It is the \
+only path for ad-hoc exploration — quick math, formatting, sanity checks, \
+inspecting an object's structure. Use sparingly; the user reviews and \
+approves every invocation, so prefer skills when one fits.
 
-**run_file and execute_python_code BOTH support the same `credentials` \
-argument.** If a script needs stored secrets, pass the credentials to \
-run_file — there is never a reason to switch to execute_python_code just to \
-get credentials. Both tools resolve credentials identically.
-
-**execute_python_code is ONLY for** quick one-off commands like checking \
-file sizes, listing a directory, printing environment info, or other short \
-exploratory commands that are not the main task. Do not install packages \
-with pip — declare dependencies via PEP 723 inline script metadata in the \
-file you write_file, and run_file will resolve them automatically with \
-`uv run`.
+**Do NOT** try to write scripts to disk and execute them yourself — there is \
+no write_file tool. To run a script, the script must come from a skill.
 
 ## Sandbox environment
 
-Code runs in a minimal Python 3.12 container with uv installed. The working \
-directory is /home/daytona. Only /home/daytona and /tmp are writable — do not \
-write to /output, /data, or other system paths. Always save output files to \
-the working directory (e.g., 'results.txt', not '/output/results.txt').
+Code runs in a minimal Python 3.12 container with uv installed.
 
-Scripts executed via run_file are run with `uv run`, which automatically \
-resolves PEP 723 inline script dependencies. Declare dependencies in a \
-comment header at the top of your script:
+**You cannot write to disk.** There is no file-write capability. Anything \
+you produce in `execute_python_code` lives only in stdout (which is returned \
+to you and shown to the user). To produce a persistent file, invoke a skill \
+that writes the file as part of its operation; if no skill exists for what \
+you need, say so and let the user decide whether to add one.
 
-```python
-# /// script
-# requires-python = ">=3.12"
-# dependencies = ["pandas", "matplotlib", "pyarrow"]
-# ///
-```
+**`/data`** is a shared cross-conversation cache populated by skills. You \
+read from it; you cannot write to it. If a fetch you need is not yet in \
+`/data`, invoke the skill that fetches it.
 
-This eliminates the need for subprocess pip install commands. Always use \
-inline script metadata for dependencies instead of installing packages manually.
+**`/workspace`** is the per-conversation working area populated by skills \
+that produce output (e.g. a plotting skill saving a chart). You read from \
+it; you cannot write to it.
+
+**`/skills/<name>/scripts/<file>`** is read-only to you — you can execute \
+these via run_file but cannot modify them.
+
+Scripts executed via run_file are run with `uv run`, which resolves PEP 723 \
+inline script dependencies declared by the skill author at the top of the \
+script. You don't manage dependencies; skill authors do.
 """
 
 _RESEARCH_ASSISTANT_PROMPT = """\

--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -1,7 +1,34 @@
-"""File management tools for writing files to graph state and executing them in the sandbox."""
+"""File management tools for the agent.
+
+Trust model:
+  - The agent runs as the daytona user (non-root) via su-l wrapping in
+    sandbox.exec_as_daytona. POSIX permissions on /skills/ (root-owned)
+    enforce that the agent cannot tamper with skill scripts.
+  - /workspace and /data are mountpoint-s3 volumes. The probe at
+    /tmp/daytona_ownership_probe.py confirmed mountpoint-s3 rejects
+    chown/chmod, so /workspace and /data are world-writable from inside
+    the sandbox. Filesystem permissions cannot enforce read-only on
+    those volumes; HITL approval on execute_python_code is the only
+    defense for write-from-agent attempts there.
+  - write_file is commented out under the zero-trust model — the agent
+    has no direct write tool. Side-effecting file writes happen only
+    via skill execution (run_file with /skills/<...> paths) or via
+    execute_python_code (HITL-approved arbitrary code).
+  - run_file is restricted to /skills/<name>/scripts/<file> paths only.
+    Anything else returns an error.
+  - File metadata in state["files"] is populated by the per-sandbox
+    inotify daemon's drain (see sandbox.drain_inotify_journal), keyed
+    by logical path with source labels assigned per-volume.
+
+State schema for files (path-only, no content):
+    state["files"] = {
+        "/foo.py":              {size, modified_at, source, last_event, first_seen},
+        "/data/forecast.parq":  {size, modified_at, source: "data", ...},
+        ...
+    }
+"""
 
 import asyncio
-import base64
 import logging
 import shlex
 from datetime import UTC, datetime
@@ -13,15 +40,19 @@ from langgraph.types import Command
 
 from ...credentials import redact_output
 from .sandbox import (
-    _BINARY_EXTENSIONS,
+    SANDBOX_DATA,
+    SANDBOX_SKILLS_DIR,
+    SANDBOX_WORKSPACE,
     _normalize_sandbox_upload_path,
+    drain_inotify_journal,
+    exec_skill,
+    list_workspace_files,
+    read_workspace_file,
     resolve_credentials_or_error,
+    workspace_path,
 )
 
 logger = logging.getLogger(__name__)
-
-# Maximum file size in bytes (1MB)
-_MAX_FILE_SIZE = 1_000_000
 
 
 def _build_uv_run_cmd(filename: str, script_args: list[str] | None) -> str:
@@ -36,70 +67,100 @@ def _build_uv_run_cmd(filename: str, script_args: list[str] | None) -> str:
     return f"uv run {filename} {suffix}"
 
 
-@tool
-async def write_file(
-    path: str,
-    content: str,
-    *,
-    runtime: ToolRuntime,
-) -> Command:
-    """Write a file to the conversation's virtual filesystem.
+def _logical_path(abs_path: str) -> str:
+    """Map an absolute sandbox path to its logical state["files"] form.
 
-    Use this to save code, data, or any text file that should be visible
-    to the user. Files are persisted in the conversation and can be
-    viewed, downloaded, or executed later.
-
-    Args:
-        path: File path (e.g., '/code/analysis.py', '/output/results.csv').
-        content: The full text content of the file.
+    /workspace/foo.py -> /foo.py (workspace prefix stripped — files
+    panel paths are stable across volume remounts).
+    /data/forecast.parquet -> /data/forecast.parquet (kept as-is — the
+    /data prefix distinguishes shared-volume files from workspace files
+    in a single namespace).
     """
+    if abs_path.startswith(SANDBOX_WORKSPACE + "/"):
+        return abs_path[len(SANDBOX_WORKSPACE) :]
+    if abs_path == SANDBOX_WORKSPACE:
+        return "/"
+    return abs_path
+
+
+def _normalize_logical_path(path: str) -> str:
+    """Ensure a path has a single leading slash (logical form)."""
     if not path.startswith("/"):
         path = "/" + path
+    return path
 
-    content_size = len(content.encode("utf-8"))
-    if content_size > _MAX_FILE_SIZE:
-        return Command(
-            update={
-                "messages": [
-                    ToolMessage(
-                        content=f"Error: File too large ({content_size} bytes). Maximum is {_MAX_FILE_SIZE} bytes.",
-                        tool_call_id=runtime.tool_call_id,
-                    )
-                ],
-            }
-        )
 
-    now = datetime.now(UTC).isoformat()
-    lines = content.split("\n")
+def _is_skill_path(logical_path: str) -> bool:
+    """True if the logical path refers to a script under /skills/."""
+    return logical_path.startswith(SANDBOX_SKILLS_DIR + "/")
 
-    file_data = {
-        "content": lines,
-        "source": "agent",
-        "created_at": now,
-        "modified_at": now,
-    }
 
-    result_msg = f"File written: {path} ({len(lines)} lines, {content_size} bytes)"
+def _validate_skill_path(logical_path: str) -> str | None:
+    """Reject anything that is not a clean /skills/<name>/scripts/<file> path.
 
-    # Note: file display is handled by file_written SSE event from tool_start,
-    # not stream_writer, because loadFiles() would overwrite the immediate
-    # display before the checkpoint saves.
+    Returns an error string on rejection, None if the path is acceptable.
+    Refuses paths with .. components, double slashes, empty segments, or
+    that don't end with a filename component below /skills/<name>/scripts/.
+    """
+    if not logical_path.startswith(SANDBOX_SKILLS_DIR + "/"):
+        return f"Path must be under {SANDBOX_SKILLS_DIR}/"
+    if ".." in logical_path.split("/"):
+        return "Path may not contain '..' components"
+    if "//" in logical_path:
+        return "Path may not contain consecutive slashes"
+    parts = logical_path.lstrip("/").split("/")
+    # Expected shape: skills / <name> / scripts / <file>
+    if len(parts) < 4 or parts[2] != "scripts":
+        return f"Path must be of the form {SANDBOX_SKILLS_DIR}/<name>/scripts/<file>"
+    if parts[-1] == "" or parts[1] == "":
+        return "Path has empty segment"
+    return None
 
-    return Command(
-        update={
-            "messages": [ToolMessage(content=result_msg, tool_call_id=runtime.tool_call_id)],
-            "files": {path: file_data},
-        }
-    )
+
+# ----------------------------------------------------------------------
+# write_file is COMMENTED OUT under the zero-trust model.
+#
+# Under the original design write_file let the agent put arbitrary text
+# into the conversation's persistent workspace. The user changed the
+# trust model to "the agent should NEVER be able to edit a skill script
+# or write to data," and then to the broader "lets actually remove the
+# agents ability to write any files. it can only execute files." The
+# tool is preserved here as a comment so the implementation can be
+# revived if the trust model changes; the function is not registered
+# in graph.py's _resolve_tools, so no agent has access to it.
+#
+# If reviving: also restore the file_written SSE event emission in
+# routes/chat.py (currently commented out) and re-evaluate /workspace
+# ownership in #27 — under zero-trust /workspace is root-owned via
+# mountpoint-s3 and the agent has no write capability.
+# ----------------------------------------------------------------------
+# @tool
+# async def write_file(
+#     path: str,
+#     content: str,
+#     *,
+#     runtime: ToolRuntime,
+# ) -> Command:
+#     """Write a file to the conversation's persistent workspace."""
+#     ...
+# ----------------------------------------------------------------------
 
 
 def make_run_file(db=None):
-    """Build the ``run_file`` tool with credential support.
+    """Build the ``run_file`` tool, restricted to /skills/<...> paths.
 
-    Like ``make_execute_python_code``, this is a factory because the tool
-    needs the application database to resolve stored credentials at run
-    time. The two tools share their credential semantics via
-    ``resolve_credentials_or_error`` so the LLM sees consistent behavior.
+    Under the zero-trust model the agent can execute trusted skill
+    scripts but cannot write to disk. ``run_file`` is the only path
+    for skill execution; arbitrary script paths under /workspace are
+    rejected. The script bytes were installed by the rhiza-agents
+    server (privileged path, root:root mode 0644), so the agent
+    cannot tamper with what it executes.
+
+    Skills run as root (via the unwrapped exec path through
+    ``exec_skill``) so they can write to /data, where the agent
+    cannot. This is the trusted-helper pattern: skills are vetted
+    code given elevated privileges to perform the data-acquisition
+    operations the agent itself isn't trusted with.
     """
 
     @tool
@@ -110,75 +171,40 @@ def make_run_file(db=None):
         *,
         runtime: ToolRuntime,
     ) -> Command:
-        """Execute a Python file from the conversation's virtual filesystem in the sandbox.
+        """Execute an installed skill script by path.
 
-        Reads the file content from state and runs it in the code sandbox
-        via ``uv run`` (which honors PEP 723 inline script dependencies).
-        The file must already exist (written via ``write_file`` or loaded
-        into state by a skill activation).
-
-        This is the preferred way to run any non-trivial code that the user
-        should be able to review. Always go through ``write_file`` →
-        ``run_file`` for scripts; never use ``execute_python_code`` to run
-        code that lives in (or could live in) a file.
+        The path must be under /skills/<name>/scripts/. Anything else
+        is rejected. Skills run with elevated privileges so they can
+        populate /data with downloaded artifacts; the agent cannot
+        write to /data directly under the trust model.
 
         Args:
-            path: Path of the file to execute (e.g., '/code/analysis.py').
+            path: Skill script path, e.g. '/skills/ecmwf-fetch/scripts/fetch.py'.
+                Paths outside /skills/<name>/scripts/ are rejected.
             script_args: Optional list of CLI arguments passed after the
-                script path, e.g. ``["--date", "2026-02-15", "--region",
-                "africa", "--output", "/tmp/out.zarr"]``. Each element is
-                passed as a single token; no shell interpretation. Omit or
-                pass ``None`` to run with no arguments.
+                script path. Each element is passed as a single token;
+                no shell interpretation.
             credentials: Optional list of materialization plans describing
-                which stored secrets to make available to this run. Same
-                shape as ``execute_python_code``'s ``credentials`` argument:
-
-                    {"kind": "env_vars", "names": ["TAHMO_USERNAME", "TAHMO_PASSWORD"]}
-
-                    {"kind": "file", "path": "~/.netrc",
-                     "names": ["NASA_USERNAME", "NASA_PASSWORD"],
-                     "content": "machine x login {NASA_USERNAME} password {NASA_PASSWORD}\\n"}
-
-                When a skill's activation response lists required
-                credential names (declared via a
-                ``metadata.openclaw.requires.env`` block in its SKILL.md),
-                wrap those names in an ``env_vars`` plan here.
-
-                The user must approve the run before any credential is
-                injected. Do not print, log, or echo credential values from
-                your script — the system will redact verbatim occurrences
-                from output as a backstop, and the user can see which secret
-                names you requested in the approval card.
+                which stored secrets to make available to this run. The
+                skill activation hint lists the credential names a skill
+                may use; wrap them in an ``env_vars`` plan here when
+                needed. The user must approve the run before any
+                credential is injected. Do not print, log, or echo
+                credential values from your script — the system will
+                redact verbatim occurrences from output as a backstop.
         """
-        if not path.startswith("/"):
-            path = "/" + path
-
-        files = runtime.state.get("files", {})
-        file_data = files.get(path)
-        if not file_data:
+        logical = _normalize_logical_path(path)
+        validation_error = _validate_skill_path(logical)
+        if validation_error:
             return Command(
                 update={
                     "messages": [
                         ToolMessage(
-                            content=f"Error: File not found: {path}",
+                            content=f"run_file rejected: {validation_error}. Path was {logical!r}.",
                             tool_call_id=runtime.tool_call_id,
+                            status="error",
                         )
-                    ],
-                }
-            )
-
-        content_lines = file_data.get("content", [])
-        code = "\n".join(content_lines)
-
-        if not code.strip():
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"Error: File is empty: {path}",
-                            tool_call_id=runtime.tool_call_id,
-                        )
-                    ],
+                    ]
                 }
             )
 
@@ -199,8 +225,8 @@ def make_run_file(db=None):
         thread_id = runtime.config.get("configurable", {}).get("thread_id", "default")
         materializations = credentials or []
 
-        # Resolve credentials before touching the sandbox so a bad request
-        # never has any side effects.
+        # Resolve credentials before touching the sandbox so a bad
+        # request never has any side effects.
         resolved = await resolve_credentials_or_error(db, thread_id, materializations, runtime.tool_call_id)
         if isinstance(resolved, Command):
             return resolved
@@ -209,13 +235,20 @@ def make_run_file(db=None):
         def _run():
             sandbox = _get_or_create_sandbox(thread_id)
 
-            # Apply file materializations (e.g. ~/.netrc) before running.
-            # Always 0600 — these are credential files. Daytona's
-            # ``fs.upload_file`` signature is (content_bytes, remote_path),
-            # and remote_path is resolved against the sandbox's working
-            # directory and does NOT expand ``~``, so the path is
-            # normalized first; the chmod still uses the original logical
-            # path because it runs in a shell that expands ``~``.
+            # Verify the skill script exists. Skills are installed by
+            # the activation handler (privileged path) before run_file
+            # is invoked. If missing here, either (a) the skill wasn't
+            # activated, or (b) the agent passed a path that points to
+            # a non-existent file.
+            check = sandbox.process.exec(f"test -f {shlex.quote(logical)}")
+            if check.exit_code != 0:
+                return f"Error: Skill script not found: {logical}", {}
+
+            # Apply credential file materializations. fs.upload_file
+            # goes through toolbox-api as root — files land owned root.
+            # Skills run as root too (exec_skill is unwrapped) so they
+            # can read root-owned files at mode 0600 directly. No chown
+            # to daytona is needed here; this is the run-as-root path.
             for cred_path, content in file_uploads.items():
                 upload_path = _normalize_sandbox_upload_path(cred_path)
                 try:
@@ -223,63 +256,35 @@ def make_run_file(db=None):
                 except Exception:
                     logger.warning("Failed to upload credential file %s", cred_path, exc_info=True)
                 try:
-                    sandbox.process.exec(f"chmod 600 {cred_path}")
+                    sandbox.process.exec(f"chmod 0600 {shlex.quote(cred_path)}")
                 except Exception:
                     pass
 
-            # Write the script itself to the sandbox.
-            filename = _normalize_sandbox_upload_path(path)
-            sandbox.fs.upload_file(code.encode("utf-8"), filename)
+            # Drain any pre-existing inotify events so this run's
+            # session-file delta starts clean.
+            drain_inotify_journal(sandbox, default_source="output")
 
-            # Snapshot files after upload but before execution to detect new output files
-            try:
-                pre_files = {f.name for f in sandbox.fs.list_files(".")}
-            except Exception:
-                pre_files = set()
+            # Skills run as root via the unwrapped exec_skill path.
+            # cwd defaults to /workspace so output files default to
+            # the persistent per-conversation working area.
+            response = exec_skill(
+                sandbox,
+                logical,
+                script_args=script_args,
+                cwd=SANDBOX_WORKSPACE,
+                env=dict(env_vars) if env_vars else None,
+            )
 
-            cmd = _build_uv_run_cmd(filename, script_args)
+            # Capture new files via the inotify journal. Source
+            # defaults to "output" for /workspace paths; /data paths
+            # are auto-relabeled to "data" inside the drain.
+            new_files = drain_inotify_journal(sandbox, default_source="output")
 
-            # sandbox.process.exec accepts an env dict that's merged into
-            # the process environment for this single command, which is
-            # exactly the per-execution scoping we want for credentials.
-            if env_vars:
-                response = sandbox.process.exec(cmd, env=dict(env_vars))
-            else:
-                response = sandbox.process.exec(cmd)
-
-            # Discover new files created during execution
-            new_files = {}
-            try:
-                post_files = sandbox.fs.list_files(".")
-                for f in post_files:
-                    if f.is_dir or f.name in pre_files:
-                        continue
-                    # Download new output files (skip large files > 1MB)
-                    if f.size and f.size > 1_000_000:
-                        continue
-                    try:
-                        content_bytes = sandbox.fs.download_file(f.name)
-                        ext = "." + f.name.rsplit(".", 1)[-1].lower() if "." in f.name else ""
-                        if ext in _BINARY_EXTENSIONS:
-                            new_files[f"/{f.name}"] = {
-                                "content": base64.b64encode(content_bytes).decode("ascii"),
-                                "encoding": "base64",
-                            }
-                        else:
-                            new_files[f"/{f.name}"] = {
-                                "content": content_bytes.decode("utf-8", errors="replace"),
-                                "encoding": "utf-8",
-                            }
-                    except Exception:
-                        pass
-            except Exception:
-                pass
-
-            # Best-effort cleanup of credential files so they don't linger
-            # between executions.
+            # Best-effort cleanup of credential files. Run as root
+            # via the unwrapped exec path.
             for cred_path in file_uploads:
                 try:
-                    sandbox.process.exec(f"rm -f {cred_path}")
+                    sandbox.process.exec(f"rm -f {shlex.quote(cred_path)}")
                 except Exception:
                     pass
 
@@ -292,41 +297,115 @@ def make_run_file(db=None):
         # Backstop: scrub verbatim secret values from anything we return.
         result = redact_output(result, redaction_list)
 
-        # Add any output files to state, with values redacted.
-        now = datetime.now(UTC).isoformat()
-        files_update = {}
-        for fpath, finfo in new_files.items():
-            encoding = finfo["encoding"]
-            raw = finfo["content"]
-            if encoding == "base64":
-                files_update[fpath] = {
-                    "content": [raw],  # Single base64 string as one "line"
-                    "source": "output",
-                    "encoding": "base64",
-                    "modified_at": now,
-                }
-            else:
-                redacted = redact_output(raw, redaction_list)
-                lines = redacted.split("\n")
-                files_update[fpath] = {
-                    "content": lines,
-                    "source": "output",
-                    "modified_at": now,
-                }
-
-        update_dict = {
+        update_dict: dict = {
             "messages": [
                 ToolMessage(
-                    content=f"Execution output for {path}:\n{result}",
+                    content=f"Execution output for {logical}:\n{result}",
                     tool_call_id=runtime.tool_call_id,
                 )
             ],
         }
 
-        if files_update:
-            existing_files = runtime.state.get("files", {})
-            update_dict["files"] = {**existing_files, **files_update}
+        if new_files:
+            update_dict["files"] = new_files
 
         return Command(update=update_dict)
 
     return run_file
+
+
+# Public helper exposed for the file-viewer endpoint to read a logical path
+# from the sandbox without needing to know about workspace_path/abs_path.
+async def fetch_file_content(
+    thread_id: str, logical_path: str, legacy_fallback: bytes | None = None
+) -> tuple[bytes, str]:
+    """Fetch a logical file path's content from the sandbox.
+
+    Returns (content_bytes, modified_at_iso). Lazy-creates the sandbox
+    if none exists for the thread. Raises FileNotFoundError if the
+    file does not exist on the sandbox filesystem and no legacy
+    fallback was provided.
+
+    ``legacy_fallback`` lets the caller migrate pre-volume state-stored
+    content on first read: when the file is absent from the volume but
+    state has its content, the caller passes those bytes. The function
+    writes them via the privileged path (toolbox-api as root) and
+    proceeds as if the file had been there.
+    """
+    from .sandbox import _get_or_create_sandbox, write_workspace_file
+
+    abs_path = workspace_path(_normalize_logical_path(logical_path))
+
+    def _fetch():
+        sandbox = _get_or_create_sandbox(thread_id)
+
+        def _stat_and_read():
+            stat_cmd = f"stat -c '%s|%Y' {shlex.quote(abs_path)}"
+            stat_resp = sandbox.process.exec(stat_cmd)
+            if stat_resp.exit_code != 0:
+                return None
+            try:
+                _, mtime_s = stat_resp.result.strip().split("|")
+                mtime = float(mtime_s)
+            except ValueError:
+                return None
+            content = read_workspace_file(sandbox, abs_path)
+            return content, datetime.fromtimestamp(mtime, tz=UTC).isoformat()
+
+        result = _stat_and_read()
+        if result is None and legacy_fallback is not None:
+            try:
+                write_workspace_file(sandbox, abs_path, legacy_fallback)
+                logger.info("Lazy-migrated legacy file %s to workspace volume", logical_path)
+            except Exception as e:
+                raise FileNotFoundError(logical_path) from e
+            result = _stat_and_read()
+
+        if result is None:
+            raise FileNotFoundError(logical_path)
+        return result
+
+    return await asyncio.to_thread(_fetch)
+
+
+async def list_thread_files(thread_id: str) -> list[dict]:
+    """List files on the thread's workspace and shared data volumes.
+
+    Used by the "all files" file-panel toggle. Returns logical-path
+    entries with source labels matching state["files"] format, so the
+    UI can render both views consistently. Includes both volumes:
+      - /workspace listed under logical paths (no /workspace prefix)
+      - /data listed under /data/... paths
+    /skills/ is intentionally excluded — skill scripts are runtime
+    plumbing, not user-visible content.
+    """
+    from .sandbox import _get_or_create_sandbox
+
+    def _list():
+        sandbox = _get_or_create_sandbox(thread_id)
+        out: list[dict] = []
+        # Workspace files: source label "workspace" (live-listing view
+        # source — distinct from the state-tracking sources "agent" /
+        # "output" / "skill" / "data" used in the session view).
+        for f in list_workspace_files(sandbox, SANDBOX_WORKSPACE):
+            out.append(
+                {
+                    "path": _logical_path(f["path"]),
+                    "size": f["size"],
+                    "modified_at": f["modified_at"],
+                    "source": "workspace",
+                }
+            )
+        # Data files: keep absolute /data/... path, label as "data".
+        for f in list_workspace_files(sandbox, SANDBOX_DATA):
+            out.append(
+                {
+                    "path": f["path"],
+                    "size": f["size"],
+                    "modified_at": f["modified_at"],
+                    "source": "data",
+                }
+            )
+        return out
+
+    return await asyncio.to_thread(_list)

--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -10,10 +10,9 @@ Trust model:
     the sandbox. Filesystem permissions cannot enforce read-only on
     those volumes; HITL approval on execute_python_code is the only
     defense for write-from-agent attempts there.
-  - write_file is commented out under the zero-trust model — the agent
-    has no direct write tool. Side-effecting file writes happen only
-    via skill execution (run_file with /skills/<...> paths) or via
-    execute_python_code (HITL-approved arbitrary code).
+  - The agent has no direct file-write tool. Side-effecting file writes
+    happen only via skill execution (run_file with /skills/<...> paths)
+    or via execute_python_code (HITL-approved arbitrary code).
   - run_file is restricted to /skills/<name>/scripts/<file> paths only.
     Anything else returns an error.
   - File metadata in state["files"] is populated by the per-sandbox
@@ -115,35 +114,6 @@ def _validate_skill_path(logical_path: str) -> str | None:
     if parts[-1] == "" or parts[1] == "":
         return "Path has empty segment"
     return None
-
-
-# ----------------------------------------------------------------------
-# write_file is COMMENTED OUT under the zero-trust model.
-#
-# Under the original design write_file let the agent put arbitrary text
-# into the conversation's persistent workspace. The user changed the
-# trust model to "the agent should NEVER be able to edit a skill script
-# or write to data," and then to the broader "lets actually remove the
-# agents ability to write any files. it can only execute files." The
-# tool is preserved here as a comment so the implementation can be
-# revived if the trust model changes; the function is not registered
-# in graph.py's _resolve_tools, so no agent has access to it.
-#
-# If reviving: also restore the file_written SSE event emission in
-# routes/chat.py (currently commented out) and re-evaluate /workspace
-# ownership in #27 — under zero-trust /workspace is root-owned via
-# mountpoint-s3 and the agent has no write capability.
-# ----------------------------------------------------------------------
-# @tool
-# async def write_file(
-#     path: str,
-#     content: str,
-#     *,
-#     runtime: ToolRuntime,
-# ) -> Command:
-#     """Write a file to the conversation's persistent workspace."""
-#     ...
-# ----------------------------------------------------------------------
 
 
 def make_run_file(db=None):

--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -100,6 +100,9 @@ def _validate_skill_path(logical_path: str) -> str | None:
     Returns an error string on rejection, None if the path is acceptable.
     Refuses paths with .. components, double slashes, empty segments, or
     that don't end with a filename component below /skills/<name>/scripts/.
+
+    The empty-skill-name case (``/skills//scripts/x``) is caught by the
+    consecutive-slashes check above, not by a redundant parts[1] check.
     """
     if not logical_path.startswith(SANDBOX_SKILLS_DIR + "/"):
         return f"Path must be under {SANDBOX_SKILLS_DIR}/"
@@ -111,7 +114,7 @@ def _validate_skill_path(logical_path: str) -> str | None:
     # Expected shape: skills / <name> / scripts / <file>
     if len(parts) < 4 or parts[2] != "scripts":
         return f"Path must be of the form {SANDBOX_SKILLS_DIR}/<name>/scripts/<file>"
-    if parts[-1] == "" or parts[1] == "":
+    if parts[-1] == "":
         return "Path has empty segment"
     return None
 

--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -324,12 +324,12 @@ async def fetch_file_content(
     writes them via the privileged path (toolbox-api as root) and
     proceeds as if the file had been there.
     """
-    from .sandbox import _get_or_create_sandbox, write_workspace_file
+    from .sandbox import _assert_realpath_contained, _get_or_create_sandbox, write_workspace_file
 
-    # workspace_path rejects traversal (paths escaping /workspace or
-    # /data) with ValueError. Map it to FileNotFoundError so the route
-    # returns 404 and no stat/read/migration-write runs as root against a
-    # path outside the permitted roots.
+    # workspace_path rejects lexical traversal (paths escaping /workspace
+    # or /data via ``..``) with ValueError. Map it to FileNotFoundError so
+    # the route returns 404 and no stat/read/migration-write runs as root
+    # against a path outside the permitted roots.
     try:
         abs_path = workspace_path(_normalize_logical_path(logical_path))
     except ValueError as e:
@@ -339,6 +339,13 @@ async def fetch_file_content(
         sandbox = _get_or_create_sandbox(thread_id)
 
         def _stat_and_read():
+            # Symlink-escape guard: resolve the real path in-sandbox and
+            # confirm it stays under /workspace or /data before any stat
+            # or read. The lexical workspace_path check can't see a symlink
+            # the agent planted in the sandbox FS; this can. An escape
+            # raises ValueError, mapped to FileNotFoundError below so the
+            # route returns 404 and no root-level read fires.
+            _assert_realpath_contained(sandbox, abs_path, resolve_parent=False)
             stat_cmd = f"stat -c '%s|%Y' {shlex.quote(abs_path)}"
             stat_resp = sandbox.process.exec(stat_cmd)
             if stat_resp.exit_code != 0:
@@ -357,7 +364,14 @@ async def fetch_file_content(
             content = read_workspace_file(sandbox, abs_path)
             return content, datetime.fromtimestamp(mtime, tz=UTC).isoformat()
 
-        result = _stat_and_read()
+        # A symlink-escape (ValueError from the realpath guard inside
+        # _stat_and_read) is mapped to FileNotFoundError so the route
+        # returns 404 and no escaped path is read. FileTooLargeError is
+        # let through so the route can map it to 413.
+        try:
+            result = _stat_and_read()
+        except ValueError as e:
+            raise FileNotFoundError(logical_path) from e
         if result is None and legacy_fallback is not None:
             # Don't migrate an oversized fallback onto the volume just to
             # reject it on re-stat — reject up front.
@@ -368,7 +382,10 @@ async def fetch_file_content(
                 logger.info("Lazy-migrated legacy file %s to workspace volume", logical_path)
             except Exception as e:
                 raise FileNotFoundError(logical_path) from e
-            result = _stat_and_read()
+            try:
+                result = _stat_and_read()
+            except ValueError as e:
+                raise FileNotFoundError(logical_path) from e
 
         if result is None:
             raise FileNotFoundError(logical_path)

--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -307,7 +307,14 @@ async def fetch_file_content(
     """
     from .sandbox import _get_or_create_sandbox, write_workspace_file
 
-    abs_path = workspace_path(_normalize_logical_path(logical_path))
+    # workspace_path rejects traversal (paths escaping /workspace or
+    # /data) with ValueError. Map it to FileNotFoundError so the route
+    # returns 404 and no stat/read/migration-write runs as root against a
+    # path outside the permitted roots.
+    try:
+        abs_path = workspace_path(_normalize_logical_path(logical_path))
+    except ValueError as e:
+        raise FileNotFoundError(logical_path) from e
 
     def _fetch():
         sandbox = _get_or_create_sandbox(thread_id)

--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -362,6 +362,12 @@ async def fetch_file_content(
             if size > MAX_FETCH_FILE_BYTES:
                 raise FileTooLargeError(logical_path, size)
             content = read_workspace_file(sandbox, abs_path)
+            # TOCTOU guard: the stat above and this read are separate
+            # exec calls, so the file could have grown past the cap in
+            # between (defeating the stat-based check). Bound on the
+            # actual bytes read, not just the earlier stat size.
+            if len(content) > MAX_FETCH_FILE_BYTES:
+                raise FileTooLargeError(logical_path, len(content))
             return content, datetime.fromtimestamp(mtime, tz=UTC).isoformat()
 
         # A symlink-escape (ValueError from the realpath guard inside

--- a/src/rhiza_agents/agents/tools/files.py
+++ b/src/rhiza_agents/agents/tools/files.py
@@ -53,6 +53,25 @@ from .sandbox import (
 
 logger = logging.getLogger(__name__)
 
+# Upper bound on a single file fetch/download. The endpoint reads the
+# whole file into memory (base64 for the JSON view, raw bytes for the
+# download), so an unbounded read of a multi-GB artifact on /data would
+# OOM the server. Files above this size are rejected before any read.
+MAX_FETCH_FILE_BYTES = 50 * 1024 * 1024  # 50 MiB
+
+
+class FileTooLargeError(Exception):
+    """Raised when a fetched file exceeds MAX_FETCH_FILE_BYTES.
+
+    Carries the offending size so the route can surface it. Routes map
+    this to HTTP 413 (Payload Too Large).
+    """
+
+    def __init__(self, logical_path: str, size: int):
+        self.logical_path = logical_path
+        self.size = size
+        super().__init__(f"{logical_path} is {size} bytes (limit {MAX_FETCH_FILE_BYTES})")
+
 
 def _build_uv_run_cmd(filename: str, script_args: list[str] | None) -> str:
     """Build the ``uv run ...`` shell command with each arg shell-quoted.
@@ -325,15 +344,25 @@ async def fetch_file_content(
             if stat_resp.exit_code != 0:
                 return None
             try:
-                _, mtime_s = stat_resp.result.strip().split("|")
+                size_s, mtime_s = stat_resp.result.strip().split("|")
+                size = int(size_s)
                 mtime = float(mtime_s)
             except ValueError:
                 return None
+            # Reject oversized files BEFORE read_workspace_file pulls the
+            # whole content into memory — a multi-GB artifact would
+            # otherwise OOM the server.
+            if size > MAX_FETCH_FILE_BYTES:
+                raise FileTooLargeError(logical_path, size)
             content = read_workspace_file(sandbox, abs_path)
             return content, datetime.fromtimestamp(mtime, tz=UTC).isoformat()
 
         result = _stat_and_read()
         if result is None and legacy_fallback is not None:
+            # Don't migrate an oversized fallback onto the volume just to
+            # reject it on re-stat — reject up front.
+            if len(legacy_fallback) > MAX_FETCH_FILE_BYTES:
+                raise FileTooLargeError(logical_path, len(legacy_fallback))
             try:
                 write_workspace_file(sandbox, abs_path, legacy_fallback)
                 logger.info("Lazy-migrated legacy file %s to workspace volume", logical_path)

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -550,12 +550,21 @@ def _build_volume_mounts(thread_id: str):
 def cleanup_thread_workspace(thread_id: str) -> None:
     """Remove a thread's subpath from the homes volume.
 
-    Called when a conversation is deleted. Mounts the homes volume in a
-    short-lived sandbox and ``rm -rf``s the per-thread directory. No-op if
-    no homes volume is configured.
+    Called when a conversation is deleted. The Daytona platform's volume
+    API has no direct file-delete operation, so the cleanup runs as a
+    shell command in a sandbox that has the homes volume mounted at this
+    thread's subpath. Two paths:
 
-    The Daytona platform's volume API has no direct file-delete operation,
-    so a temporary sandbox is the only path to remove subpath contents.
+      1. If the per-thread sandbox is still alive in ``_sandboxes``, run
+         the ``rm`` through it. Its mount already points at the right
+         volume + subpath, so this saves the ~5–15s sandbox-create cost.
+         For this to fire, the caller must invoke this BEFORE
+         ``cleanup_sandbox`` (which removes the entry from ``_sandboxes``).
+      2. Otherwise spin up a temp sandbox just to do the rm. This handles
+         the case where the active sandbox was already idle-cleaned, or
+         where the conversation never had an active sandbox in this
+         server process.
+
     Best-effort: failures are logged, never raised, since the conversation
     DB row is already gone by the time this runs.
     """
@@ -564,12 +573,36 @@ def cleanup_thread_workspace(thread_id: str) -> None:
         return
 
     homes_path = os.environ.get(_HOMES_MOUNT_PATH_ENV, "").strip() or SANDBOX_WORKSPACE
+    rm_cmd = f"find {shlex.quote(homes_path)} -mindepth 1 -delete"
 
+    # Path 1: reuse the active per-thread sandbox if alive.
+    active = _sandboxes.get(thread_id)
+    if active is not None:
+        try:
+            response = active.process.exec(rm_cmd)
+            if response.exit_code != 0:
+                logger.warning(
+                    "Workspace cleanup for thread %s (active sandbox) exited %d: %s",
+                    thread_id,
+                    response.exit_code,
+                    response.result,
+                )
+            return
+        except Exception:
+            logger.warning(
+                "Active-sandbox workspace cleanup failed for thread %s; falling back to temp sandbox",
+                thread_id,
+                exc_info=True,
+            )
+            # Fall through to path 2.
+
+    # Path 2: no live sandbox (or the active path failed). Spin up a
+    # temp sandbox just to do the rm.
     try:
         from daytona_sdk import CreateSandboxFromImageParams, Image, VolumeMount
 
         vol = _get_daytona().volume.get(homes_name, create=False)
-        # Minimal image — no need for git/uv since we just rm -rf
+        # Minimal image — no need for git/uv since we just rm -rf.
         image = Image.debian_slim("3.12")
         sb = _get_daytona().create(
             CreateSandboxFromImageParams(
@@ -578,11 +611,10 @@ def cleanup_thread_workspace(thread_id: str) -> None:
             )
         )
         try:
-            # The mount only exposes the thread's subpath, so rm everything inside.
-            response = sb.process.exec(f"find {shlex.quote(homes_path)} -mindepth 1 -delete")
+            response = sb.process.exec(rm_cmd)
             if response.exit_code != 0:
                 logger.warning(
-                    "Workspace cleanup for thread %s exited %d: %s",
+                    "Workspace cleanup for thread %s (temp sandbox) exited %d: %s",
                     thread_id,
                     response.exit_code,
                     response.result,

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -20,6 +20,7 @@ import asyncio
 import base64
 import logging
 import os
+import shlex
 from datetime import UTC, datetime
 from typing import Any
 
@@ -37,12 +38,11 @@ from ...credentials import (
 
 logger = logging.getLogger(__name__)
 
-# File extensions that should be stored as base64-encoded binary
 # Daytona's filesystem API (``sandbox.fs.upload_file``) treats paths as
-# relative to the sandbox's home directory. Passing ``~/.netrc`` literally
-# creates a directory named ``~`` instead of expanding the tilde, and
-# passing absolute paths like ``/root/.netrc`` ends up under
-# ``<home>/root/.netrc``. Normalize all credential file paths through this
+# relative to the sandbox's working directory (which is the user's home,
+# /root, by default). Passing ``~/.netrc`` literally creates a directory
+# named ``~``; absolute paths like ``/root/.netrc`` end up under
+# ``<cwd>/root/.netrc``. Normalize credential file paths through this
 # helper so they land where the script expects to find them.
 #
 # Shell commands like ``chmod`` and ``rm`` go through ``sandbox.process.exec``
@@ -50,9 +50,42 @@ logger = logging.getLogger(__name__)
 # original logical path.
 _SANDBOX_HOME = "/root"
 
+# Per-thread persistent working directory. Mounted via the homes volume
+# with subpath=<thread_id> so files survive sandbox idle cleanup.
+SANDBOX_WORKSPACE = "/workspace"
+
+# Non-root user the agent's tool calls execute as. Created in the image
+# via `useradd`, then every agent-driven `process.exec` is wrapped in
+# `su -l daytona -c '<cmd>'` so the agent cannot escalate to root.
+# `os_user="daytona"` is also passed at sandbox creation for metadata
+# correctness, but it does not enforce per-command identity (Daytona open
+# issue #4309) — the wrap is what actually enforces it.
+SANDBOX_DAYTONA_USER = "daytona"
+SANDBOX_DAYTONA_HOME = "/home/daytona"
+
+# Trusted-skill directory. Lives on the regular container filesystem
+# (NOT a volume), so POSIX permissions actually enforce: owned root:root
+# mode 0644 means daytona can read+execute but not modify. Skill scripts
+# are installed here at activation time via the privileged path
+# (sandbox.fs.upload_file → toolbox-api as root, then chmod 0644).
+SANDBOX_SKILLS_DIR = "/skills"
+
+# Inotify journal: where the per-sandbox daemon records file events
+# (create / modify / open / access / close_write) on /workspace and
+# /data. Drained after every agent tool call to populate state["files"]
+# with paths the conversation touched. Owned by daytona so the agent
+# user can read it; the daemon itself runs as daytona too (events fire
+# regardless of the watching user, but running as daytona keeps the
+# log file ownership consistent).
+INOTIFY_JOURNAL_PATH = "/tmp/inotify.log"
+
 
 def _normalize_sandbox_upload_path(path: str) -> str:
-    """Convert a logical sandbox path to the form Daytona's fs.upload_file expects."""
+    """Convert a logical credential-file path to the form Daytona's fs.upload_file expects.
+
+    Used only for credential files (which still live under $HOME=/root).
+    User scripts and outputs go to SANDBOX_WORKSPACE via shell-based writes.
+    """
     if path.startswith("~/"):
         return path[2:]
     if path.startswith(_SANDBOX_HOME + "/"):
@@ -62,38 +95,91 @@ def _normalize_sandbox_upload_path(path: str) -> str:
     return path
 
 
-_BINARY_EXTENSIONS = {
-    ".png",
-    ".jpg",
-    ".jpeg",
-    ".gif",
-    ".bmp",
-    ".webp",
-    ".svg",
-    ".ico",
-    ".pdf",
-    ".zip",
-    ".tar",
-    ".gz",
-    ".bz2",
-    ".mp3",
-    ".wav",
-    ".ogg",
-    ".mp4",
-    ".avi",
-    ".mov",
-    ".webm",
-    ".woff",
-    ".woff2",
-    ".ttf",
-    ".eot",
-    ".pkl",
-    ".pickle",
-    ".npy",
-    ".npz",
-    ".parquet",
-    ".feather",
-}
+# Shared cross-conversation data volume. Mounted at SANDBOX_DATA via the
+# DAYTONA_DATA_VOLUME env var. Files written here by scripts are visible
+# to every conversation that mounts the same data volume.
+SANDBOX_DATA = "/data"
+
+
+def workspace_path(logical_path: str) -> str:
+    """Map a logical file path to its absolute location in the sandbox.
+
+    Logical paths starting with ``/data/`` (or exactly ``/data``) refer to
+    files on the shared data volume and are returned as-is. Everything
+    else maps under SANDBOX_WORKSPACE (the per-conversation persistent
+    working area).
+
+    The two-prefix scheme keeps state["files"] keys unambiguous: a file on
+    the data volume is identified by its ``/data/...`` path, a file in
+    the workspace by a path that does not start with ``/data/``.
+    """
+    if logical_path == SANDBOX_DATA or logical_path.startswith(SANDBOX_DATA + "/"):
+        return logical_path
+    rel = logical_path.lstrip("/")
+    return f"{SANDBOX_WORKSPACE}/{rel}"
+
+
+def write_workspace_file(sandbox, abs_path: str, content: bytes) -> None:
+    """Write bytes to an absolute path in the sandbox.
+
+    fs.upload_file resolves relative-to-cwd; absolute paths are not
+    respected. Use shell + base64 to write to arbitrary absolute paths.
+    Caller is responsible for shell-safe ``abs_path`` (this helper quotes it).
+    """
+    b64 = base64.b64encode(content).decode("ascii")
+    quoted = shlex.quote(abs_path)
+    parent = os.path.dirname(abs_path) or "/"
+    cmd = f"mkdir -p {shlex.quote(parent)} && echo {shlex.quote(b64)} | base64 -d > {quoted}"
+    response = sandbox.process.exec(cmd)
+    if response.exit_code != 0:
+        raise OSError(f"Failed to write {abs_path}: {response.result}")
+
+
+def read_workspace_file(sandbox, abs_path: str) -> bytes:
+    """Read bytes from an absolute path in the sandbox via shell + base64.
+
+    fs.download_file is relative-to-cwd; this is the absolute-path equivalent.
+    Raises FileNotFoundError if the path does not exist.
+    """
+    quoted = shlex.quote(abs_path)
+    response = sandbox.process.exec(f"test -f {quoted} && base64 -w 0 {quoted}")
+    if response.exit_code != 0:
+        raise FileNotFoundError(abs_path)
+    return base64.b64decode(response.result.strip())
+
+
+def list_workspace_files(sandbox, abs_dir: str) -> list[dict]:
+    """List files under an absolute directory in the sandbox.
+
+    Returns list of {path, size, modified_at} for regular files only,
+    recursively. Returns empty list if the directory does not exist or is empty.
+    """
+    quoted = shlex.quote(abs_dir)
+    # Use find + stat, format as TSV for safe parsing
+    cmd = f"test -d {quoted} || exit 0; find {quoted} -type f -printf '%p\\t%s\\t%T@\\n' 2>/dev/null"
+    response = sandbox.process.exec(cmd)
+    if response.exit_code != 0:
+        return []
+    out: list[dict] = []
+    for line in response.result.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        path, size_s, mtime_s = parts
+        try:
+            size = int(size_s)
+            mtime = float(mtime_s)
+        except ValueError:
+            continue
+        out.append(
+            {
+                "path": path,
+                "size": size,
+                "modified_at": datetime.fromtimestamp(mtime, tz=UTC).isoformat(),
+            }
+        )
+    return out
+
 
 IDLE_TIMEOUT_MINUTES = 15
 
@@ -101,6 +187,213 @@ IDLE_TIMEOUT_MINUTES = 15
 _sandboxes: dict[str, object] = {}
 _last_used: dict[str, datetime] = {}
 _daytona = None
+
+
+def exec_as_daytona(sandbox, command: str, cwd: str | None = None, env: dict[str, str] | None = None):
+    """Run a shell command as the daytona user via `su -l`.
+
+    Daytona's process.exec executes commands as root by default
+    (Daytona's `os_user` is metadata only — open issue #4309). Wrapping
+    in `su -l daytona -c '...'` is the only way to actually drop
+    privileges for agent-supplied or agent-invoked code. The login shell
+    (`-l`) resets PATH/HOME to daytona's defaults; `cwd` and `env` are
+    injected inside the wrapped command because su strips the parent
+    process's environment.
+
+    The command is base64-encoded before being passed through `su -c`
+    to avoid shell-quoting hazards (the command may contain quotes,
+    backticks, $-expansions the agent supplied).
+    """
+    parts: list[str] = []
+    if env:
+        for k, v in env.items():
+            parts.append(f"export {shlex.quote(k)}={shlex.quote(v)}")
+    if cwd:
+        parts.append(f"cd {shlex.quote(cwd)}")
+    parts.append(command)
+    inner = "; ".join(parts)
+    b64 = base64.b64encode(inner.encode()).decode("ascii")
+    wrapped = f'su -l {SANDBOX_DAYTONA_USER} -c "echo {shlex.quote(b64)} | base64 -d | sh"'
+    return sandbox.process.exec(wrapped)
+
+
+def exec_skill(
+    sandbox,
+    abs_skill_path: str,
+    script_args: list[str] | None = None,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+):
+    """Run a script under /skills/ as root via the unwrapped exec path.
+
+    Skills are trusted code (root-owned, agent cannot modify), so they
+    execute with elevated privileges — they need root to write to /data
+    (mountpoint-s3 mounts are world-writable in practice, but the trust
+    model is "only skills write to /data" by convention).
+
+    Path validation: ``abs_skill_path`` must already be an absolute
+    path strictly under SANDBOX_SKILLS_DIR. Caller is responsible for
+    normalizing logical paths (e.g. "/skills/foo/bar.py" → absolute) and
+    rejecting any path that does not satisfy the prefix check. This
+    function performs a final defensive check and raises ValueError
+    otherwise — defense-in-depth even though the agent has no path to
+    plant a symlink in /skills/ (root-owned, daytona has no write).
+    """
+    if not abs_skill_path.startswith(SANDBOX_SKILLS_DIR + "/"):
+        raise ValueError(f"exec_skill called with non-skill path: {abs_skill_path!r}")
+    if "/../" in abs_skill_path or abs_skill_path.endswith("/.."):
+        raise ValueError(f"path traversal in skill path: {abs_skill_path!r}")
+
+    quoted_path = shlex.quote(abs_skill_path)
+    if script_args:
+        suffix = " ".join(shlex.quote(a) for a in script_args)
+        cmd = f"uv run {quoted_path} {suffix}"
+    else:
+        cmd = f"uv run {quoted_path}"
+
+    exec_kwargs: dict = {}
+    if cwd:
+        exec_kwargs["cwd"] = cwd
+    if env:
+        exec_kwargs["env"] = dict(env)
+    return sandbox.process.exec(cmd, **exec_kwargs)
+
+
+def start_inotify_daemon(sandbox) -> None:
+    """Start an inotifywait daemon that records file events to INOTIFY_JOURNAL_PATH.
+
+    Watches SANDBOX_WORKSPACE and SANDBOX_DATA recursively for create,
+    modify, close_write, open, and access events. Output format is
+    TSV: ``<event>\\t<path>\\t<unix_timestamp>``. The daemon runs in
+    the background (nohup + &) so process.exec returns immediately.
+
+    Best-effort: if inotifywait is missing or the watch can't start
+    (e.g. inotify limits exhausted), logs and continues without
+    session tracking — agent calls still work.
+
+    Runs as daytona (via exec_as_daytona). Inotify events fire
+    based on filesystem events regardless of which user's process
+    triggered them, so running as daytona vs root is purely about
+    journal-file ownership; daytona is consistent with the rest of
+    the per-sandbox file ownership.
+    """
+    journal = shlex.quote(INOTIFY_JOURNAL_PATH)
+    workspace = shlex.quote(SANDBOX_WORKSPACE)
+    data = shlex.quote(SANDBOX_DATA)
+    # Truncate any previous journal (daemon may have left one if a
+    # different conversation reused the same sandbox name — shouldn't
+    # happen with our per-thread sandboxes, but defensive).
+    init_cmd = (
+        f": > {journal}; "
+        # Start the daemon. -m monitor mode (don't exit), -r recursive,
+        # -e events. --format produces TSV; --timefmt %s makes the
+        # timestamp a unix epoch second so we don't have to parse a
+        # human date string in the drain.
+        f"nohup inotifywait -mr "
+        f"-e create -e modify -e close_write -e open -e access "
+        f"--format '%e\\t%w%f\\t%T' --timefmt '%s' "
+        f"{workspace} {data} > {journal} 2>&1 &"
+    )
+    response = exec_as_daytona(sandbox, init_cmd)
+    if response.exit_code != 0:
+        logger.warning(
+            "Failed to start inotify daemon (session tracking disabled): %s",
+            response.result,
+        )
+
+
+def drain_inotify_journal(sandbox, default_source: str = "agent") -> dict[str, dict]:
+    """Read and truncate the inotify journal, return aggregated path metadata.
+
+    Returns a dict keyed by logical path (state["files"] format — leading
+    slash, no /workspace prefix; /data paths kept as-is). Each value is
+    {size, modified_at, source, last_event_type, first_seen}.
+
+    Path-to-source mapping:
+      - Paths under /data → source = "data" regardless of caller.
+      - Paths under /workspace → source = ``default_source`` (caller
+        passes "agent" for write_file / execute_python_code, "output"
+        for run_file, etc).
+      - Paths under /skills/ are filtered out — skill files are
+        runtime plumbing, not user-visible content. They never appear
+        in state["files"].
+
+    Stats each surviving path to attach size and mtime. If the path
+    no longer exists (e.g. the script was a temp file deleted before
+    the drain ran), the entry is dropped.
+    """
+    journal = shlex.quote(INOTIFY_JOURNAL_PATH)
+    # Atomic read+truncate: rename to .read so any in-flight writes
+    # from the daemon append to a fresh (empty) journal we recreate.
+    # Then cat the renamed file. Best-effort — inotifywait keeps its
+    # FD open against the renamed inode and continues writing to it
+    # until we delete it, so events that happened during the rename
+    # window are preserved in the .read copy.
+    drain_cmd = (
+        f"if [ -f {journal} ]; then "
+        f"  mv {journal} {journal}.read 2>/dev/null && : > {journal}; "
+        f"  cat {journal}.read 2>/dev/null; "
+        f"  rm -f {journal}.read; "
+        f"fi"
+    )
+    response = exec_as_daytona(sandbox, drain_cmd)
+    if response.exit_code != 0:
+        return {}
+
+    # Aggregate events per path.
+    by_path: dict[str, dict] = {}
+    for line in response.result.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        event, path, ts_s = parts
+        if not path or not path.startswith("/"):
+            continue
+        # Filter skill-internal paths.
+        if path.startswith(SANDBOX_SKILLS_DIR + "/") or path == SANDBOX_SKILLS_DIR:
+            continue
+        try:
+            ts = float(ts_s)
+        except ValueError:
+            continue
+        entry = by_path.setdefault(path, {"first_seen_ts": ts, "last_ts": ts, "last_event": event})
+        if ts >= entry["last_ts"]:
+            entry["last_ts"] = ts
+            entry["last_event"] = event
+
+    # Stat each path and build the state["files"] entries.
+    result: dict[str, dict] = {}
+    for abs_path, agg in by_path.items():
+        # Logical path: /workspace/foo → /foo, /data/bar stays /data/bar.
+        if abs_path == SANDBOX_WORKSPACE or abs_path.startswith(SANDBOX_WORKSPACE + "/"):
+            logical = abs_path[len(SANDBOX_WORKSPACE) :] or "/"
+            source = default_source
+        elif abs_path == SANDBOX_DATA or abs_path.startswith(SANDBOX_DATA + "/"):
+            logical = abs_path
+            source = "data"
+        else:
+            # Out of scope — skip events from outside watched areas.
+            continue
+
+        # Stat to get size + mtime. If gone, skip.
+        stat_resp = exec_as_daytona(sandbox, f"stat -c '%s|%Y' {shlex.quote(abs_path)}")
+        if stat_resp.exit_code != 0:
+            continue
+        try:
+            size_s, mtime_s = stat_resp.result.strip().split("|")
+            size = int(size_s)
+            mtime = float(mtime_s)
+        except (ValueError, AttributeError):
+            continue
+
+        result[logical] = {
+            "size": size,
+            "modified_at": datetime.fromtimestamp(mtime, tz=UTC).isoformat(),
+            "source": source,
+            "last_event": agg["last_event"],
+            "first_seen": datetime.fromtimestamp(agg["first_seen_ts"], tz=UTC).isoformat(),
+        }
+    return result
 
 
 def _get_daytona():
@@ -172,6 +465,144 @@ def _daytona_sandbox_resources_from_env():
     return Resources(disk=gib)
 
 
+# Volume configuration env vars. All optional — unset means no mounts and the
+# sandbox behaves as it did before persistent storage was added.
+_HOMES_VOLUME_NAME_ENV = "DAYTONA_HOMES_VOLUME"
+_HOMES_MOUNT_PATH_ENV = "DAYTONA_HOMES_MOUNT_PATH"
+_DATA_VOLUME_NAME_ENV = "DAYTONA_DATA_VOLUME"
+_DATA_MOUNT_PATH_ENV = "DAYTONA_DATA_MOUNT_PATH"
+
+
+def _build_volume_mounts(thread_id: str):
+    """Build the VolumeMount list for a sandbox, or None if no volumes configured.
+
+    The homes volume is mounted at ``DAYTONA_HOMES_MOUNT_PATH`` (default
+    ``/workspace``) with ``subpath=<thread_id>`` so each conversation gets
+    its own persistent slice. The data volume is mounted at
+    ``DAYTONA_DATA_MOUNT_PATH`` (default ``/data``) without a subpath so
+    it's shared across all conversations.
+
+    Volume lookup uses ``create=False`` so a misconfiguration fails loudly
+    rather than silently creating stray volumes.
+    """
+    from daytona_sdk import VolumeMount
+
+    mounts = []
+
+    homes_name = os.environ.get(_HOMES_VOLUME_NAME_ENV, "").strip()
+    if homes_name:
+        homes_path = os.environ.get(_HOMES_MOUNT_PATH_ENV, "").strip() or SANDBOX_WORKSPACE
+        try:
+            vol = _get_daytona().volume.get(homes_name, create=False)
+            mounts.append(VolumeMount(volume_id=vol.id, mount_path=homes_path, subpath=thread_id))
+        except Exception:
+            logger.warning(
+                "Homes volume %r not found; per-thread persistent workspace disabled", homes_name, exc_info=True
+            )
+
+    data_name = os.environ.get(_DATA_VOLUME_NAME_ENV, "").strip()
+    if data_name:
+        data_path = os.environ.get(_DATA_MOUNT_PATH_ENV, "").strip() or "/data"
+        try:
+            vol = _get_daytona().volume.get(data_name, create=False)
+            mounts.append(VolumeMount(volume_id=vol.id, mount_path=data_path))
+        except Exception:
+            logger.warning("Data volume %r not found; shared data disabled", data_name, exc_info=True)
+
+    return mounts or None
+
+
+def cleanup_thread_workspace(thread_id: str) -> None:
+    """Remove a thread's subpath from the homes volume.
+
+    Called when a conversation is deleted. Mounts the homes volume in a
+    short-lived sandbox and ``rm -rf``s the per-thread directory. No-op if
+    no homes volume is configured.
+
+    The Daytona platform's volume API has no direct file-delete operation,
+    so a temporary sandbox is the only path to remove subpath contents.
+    Best-effort: failures are logged, never raised, since the conversation
+    DB row is already gone by the time this runs.
+    """
+    homes_name = os.environ.get(_HOMES_VOLUME_NAME_ENV, "").strip()
+    if not homes_name:
+        return
+
+    homes_path = os.environ.get(_HOMES_MOUNT_PATH_ENV, "").strip() or SANDBOX_WORKSPACE
+
+    try:
+        from daytona_sdk import CreateSandboxFromImageParams, Image, VolumeMount
+
+        vol = _get_daytona().volume.get(homes_name, create=False)
+        # Minimal image — no need for git/uv since we just rm -rf
+        image = Image.debian_slim("3.12")
+        sb = _get_daytona().create(
+            CreateSandboxFromImageParams(
+                image=image,
+                volumes=[VolumeMount(volume_id=vol.id, mount_path=homes_path, subpath=thread_id)],
+            )
+        )
+        try:
+            # The mount only exposes the thread's subpath, so rm everything inside.
+            response = sb.process.exec(f"find {shlex.quote(homes_path)} -mindepth 1 -delete")
+            if response.exit_code != 0:
+                logger.warning(
+                    "Workspace cleanup for thread %s exited %d: %s",
+                    thread_id,
+                    response.exit_code,
+                    response.result,
+                )
+        finally:
+            _get_daytona().delete(sb)
+    except Exception:
+        logger.warning("Failed to clean up workspace for thread %s", thread_id, exc_info=True)
+
+
+async def cleanup_thread_workspace_async(thread_id: str) -> None:
+    """Async wrapper for ``cleanup_thread_workspace``."""
+    await asyncio.to_thread(cleanup_thread_workspace, thread_id)
+
+
+def _build_sandbox_image():
+    """Build the Daytona Image declaration for the runtime.
+
+    - python:3.12-slim base
+    - git installed (uv/pip can fetch VCS dependencies)
+    - inotify-tools installed (the inotifywait binary the per-sandbox
+      session-tracking daemon runs)
+    - uv installed via pip
+    - daytona user created (the non-root identity all agent tool calls
+      execute as via su -l wrapping)
+    - /workspace, /data, /skills directories created. Skills directory
+      is owned root:root mode 0755 — POSIX permissions actually enforce
+      here because /skills/ is on the regular container FS, not a volume.
+      /workspace and /data ownership is determined by mountpoint-s3 mount
+      options (probe confirmed they arrive nobody:nogroup mode 0777, and
+      chown/chmod from inside is not permitted) so we don't try to chown
+      them — see /tmp/daytona_ownership_probe.py for the empirical basis.
+    """
+    from daytona_sdk import Image
+
+    return (
+        Image.debian_slim("3.12")
+        .run_commands(
+            "apt-get update && apt-get install -y --no-install-recommends git inotify-tools "
+            "&& rm -rf /var/lib/apt/lists/*",
+            # Non-root user the agent's tool calls execute as. -m creates
+            # /home/daytona; -s sets the login shell; -r marks it a
+            # system account.
+            "groupadd -r daytona && useradd -r -m -g daytona -s /bin/bash daytona",
+            # Mount points / regular dirs.
+            f"mkdir -p {SANDBOX_WORKSPACE} /data {SANDBOX_SKILLS_DIR}",
+            # /skills/ stays root:root mode 0755 — agent (daytona) reads
+            # and executes but cannot write. Skill scripts dropped here at
+            # activation time get chmod 0644 (also root-owned).
+            f"chmod 0755 {SANDBOX_SKILLS_DIR}",
+        )
+        .pip_install(["uv"])
+    )
+
+
 def _get_or_create_sandbox(thread_id: str):
     """Get an existing sandbox for a thread or create a new one.
 
@@ -181,29 +612,47 @@ def _get_or_create_sandbox(thread_id: str):
     ``pip install`` / ``uv pip install`` can fetch VCS dependencies (e.g.
     ``git+https://...``).
 
+    Volume mounts are wired in based on env vars (see
+    ``_build_volume_mounts``): per-thread persistent ``/workspace`` and
+    shared ``/data`` when configured.
+
     Optional env ``DAYTONA_SANDBOX_DISK_GIB`` sets sandbox disk size (GiB);
-    see `_daytona_sandbox_resources_from_env`.
+    see ``_daytona_sandbox_resources_from_env``.
     """
-    from daytona_sdk import CreateSandboxFromImageParams, Image
+    from daytona_sdk import CreateSandboxFromImageParams
 
     _cleanup_idle_sandboxes()
 
     if thread_id not in _sandboxes:
-        image = (
-            Image.debian_slim("3.12")
-            .run_commands(
-                "apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*"
-            )
-            .pip_install(["uv"])
-        )
+        image = _build_sandbox_image()
         resources = _daytona_sandbox_resources_from_env()
-        sandbox = _get_daytona().create(CreateSandboxFromImageParams(image=image, resources=resources))
+        volumes = _build_volume_mounts(thread_id)
+        sandbox = _get_daytona().create(
+            CreateSandboxFromImageParams(
+                image=image,
+                resources=resources,
+                volumes=volumes,
+                # Metadata only — Daytona open issue #4309 confirms
+                # process.exec doesn't honor this. The actual identity
+                # for agent calls comes from exec_as_daytona's su wrap.
+                os_user=SANDBOX_DAYTONA_USER,
+            )
+        )
         _patch_proxy_url(sandbox)
         _sandboxes[thread_id] = sandbox
-        if resources is not None:
-            logger.info("Created sandbox for thread %s (with uv, git, %r)", thread_id, resources)
-        else:
-            logger.info("Created sandbox for thread %s (with uv, git)", thread_id)
+        # Best-effort start of the per-sandbox inotify daemon. Failure
+        # leaves session-tracking off for this sandbox but doesn't
+        # affect anything else.
+        try:
+            start_inotify_daemon(sandbox)
+        except Exception:
+            logger.warning("Failed to start inotify daemon for thread %s", thread_id, exc_info=True)
+        logger.info(
+            "Created sandbox for thread %s (resources=%r, volumes=%d)",
+            thread_id,
+            resources,
+            len(volumes) if volumes else 0,
+        )
 
     _last_used[thread_id] = datetime.now(UTC)
     return _sandboxes[thread_id]
@@ -464,6 +913,32 @@ async def resolve_credentials_or_error(
 def make_execute_python_code(db=None):
     """Build the ``execute_python_code`` tool with credential support.
 
+    SECURITY NOTE — residual tamper surface:
+
+    This tool is the only agent-controlled path to arbitrary code
+    execution. Under the zero-trust model:
+
+      - The agent runs as the ``daytona`` user via ``exec_as_daytona``,
+        so it cannot tamper with /skills/ (root-owned, mode 0644).
+        POSIX permissions enforce skill-script integrity.
+      - However, /workspace and /data are mountpoint-s3 volumes. The
+        ownership probe (/tmp/daytona_ownership_probe.py) confirmed that
+        chown/chmod return EPERM on those mounts even from root, and
+        mountpoint-s3 reports them as world-writable regardless of the
+        underlying user. **Filesystem permissions do not enforce
+        read-only on /workspace or /data.** The daytona user CAN write,
+        modify, or delete files there via ``execute_python_code``.
+      - HITL approval is the only defense for /workspace / /data write
+        attempts. Every ``execute_python_code`` invocation is in
+        ``_HITL_TOOLS`` (graph.py) and the user reviews the code before
+        it runs. A sufficiently subtle tamper that the user approves
+        without noticing would succeed.
+
+    The /skills/ trust story is strict (enforced by the OS); the
+    /workspace / /data integrity story is HITL-mediated. If this
+    tool is ever extended, removed, or replaced, revisit how skill
+    outputs in /workspace are protected from agent post-processing.
+
     Args:
         db: Application database. Required for credential resolution.
             When None, the tool still runs but rejects any non-empty
@@ -592,83 +1067,54 @@ def make_execute_python_code(db=None):
         def _run():
             sandbox = _get_or_create_sandbox(thread_id)
 
-            # Apply file materializations before running. These persist for
-            # the lifetime of the sandbox; future runs that don't request
-            # them will still see them in the filesystem until the sandbox
-            # is recycled. Best-effort cleanup happens after the run.
-            #
-            # Daytona's upload_file signature is (content_bytes, remote_path),
-            # NOT (remote_path, content_bytes). And remote_path is resolved
-            # against the sandbox's working directory and does NOT expand
-            # ``~``, so the path is normalized first.
+            # Apply credential file materializations before running.
+            # fs.upload_file goes through the Daytona toolbox-api as
+            # root, so files land owned root:root. After upload, chown
+            # to daytona and chmod 0600 so the daytona-context script
+            # can read them; without the chown, daytona would EACCES
+            # on a 0600 root-owned file.
             for path, content in file_uploads.items():
                 upload_path = _normalize_sandbox_upload_path(path)
                 try:
                     sandbox.fs.upload_file(content.encode("utf-8"), upload_path)
                 except Exception:
                     logger.warning("Failed to upload credential file %s", path, exc_info=True)
-                # netrc and similar credential files conventionally need
-                # restrictive permissions; default everything to 0600. Use
-                # the original logical path here — chmod runs in a shell
-                # that expands ``~`` correctly.
+                # chown + chmod via the unwrapped exec path (root) so
+                # daytona ends up able to read the file.
                 try:
-                    sandbox.process.exec(f"chmod 600 {path}")
+                    sandbox.process.exec(
+                        f"chown {SANDBOX_DAYTONA_USER}:{SANDBOX_DAYTONA_USER} {shlex.quote(path)}; "
+                        f"chmod 0600 {shlex.quote(path)}"
+                    )
                 except Exception:
                     pass
 
-            # Snapshot files before execution to detect new output files
-            try:
-                pre_files = {f.name for f in sandbox.fs.list_files(".")}
-            except Exception:
-                pre_files = set()
+            # Run the agent's code as daytona via su -l wrapping. The
+            # code is base64-encoded to avoid shell-quoting hazards from
+            # the agent's source (which may contain quotes, $-expansions,
+            # etc.). The wrapped command pipes the decoded source into
+            # python on stdin so the bytes never appear in argv (would
+            # be visible in /proc/<pid>/cmdline).
+            #
+            # Drain any pre-existing inotify events first so this run's
+            # session-file delta starts from a clean slate.
+            drain_inotify_journal(sandbox, default_source="agent")
 
-            run_params = None
-            if env_vars:
-                try:
-                    from daytona_sdk import CodeRunParams
+            code_b64 = base64.b64encode(code.encode("utf-8")).decode("ascii")
+            run_cmd = f"echo {shlex.quote(code_b64)} | base64 -d | python3"
+            response = exec_as_daytona(sandbox, run_cmd, env=env_vars or None)
 
-                    run_params = CodeRunParams(env=dict(env_vars))
-                except Exception:
-                    logger.warning("Failed to build CodeRunParams; env vars will not be set", exc_info=True)
+            # Pick up any new files the script wrote, via the inotify
+            # journal. The drain returns logical paths with proper
+            # source labels (/data → "data", /workspace → "agent").
+            new_files = drain_inotify_journal(sandbox, default_source="agent")
 
-            if run_params is not None:
-                response = sandbox.process.code_run(code, params=run_params)
-            else:
-                response = sandbox.process.code_run(code)
-
-            # Discover new files created during execution
-            new_files = {}
-            try:
-                post_files = sandbox.fs.list_files(".")
-                for f in post_files:
-                    if f.is_dir or f.name in pre_files:
-                        continue
-                    # Skip large files > 1MB
-                    if f.size and f.size > 1_000_000:
-                        continue
-                    try:
-                        content_bytes = sandbox.fs.download_file(f.name)
-                        ext = "." + f.name.rsplit(".", 1)[-1].lower() if "." in f.name else ""
-                        if ext in _BINARY_EXTENSIONS:
-                            new_files[f"/{f.name}"] = {
-                                "content": base64.b64encode(content_bytes).decode("ascii"),
-                                "encoding": "base64",
-                            }
-                        else:
-                            new_files[f"/{f.name}"] = {
-                                "content": content_bytes.decode("utf-8", errors="replace"),
-                                "encoding": "utf-8",
-                            }
-                    except Exception:
-                        pass
-            except Exception:
-                pass
-
-            # Best-effort cleanup of credential files so they don't linger
-            # between executions.
+            # Best-effort cleanup of credential files. Run as root via
+            # the unwrapped path so we can rm files we chowned to
+            # daytona (root can rm regardless).
             for path in file_uploads:
                 try:
-                    sandbox.process.exec(f"rm -f {path}")
+                    sandbox.process.exec(f"rm -f {shlex.quote(path)}")
                 except Exception:
                     pass
 
@@ -681,28 +1127,6 @@ def make_execute_python_code(db=None):
         # Backstop: scrub verbatim secret values from anything we return.
         result = redact_output(result, redaction_list)
 
-        # Build files state update from captured output files
-        now = datetime.now(UTC).isoformat()
-        files_update = {}
-        for fpath, finfo in new_files.items():
-            encoding = finfo["encoding"]
-            raw = finfo["content"]
-            if encoding == "base64":
-                files_update[fpath] = {
-                    "content": [raw],
-                    "source": "output",
-                    "encoding": "base64",
-                    "modified_at": now,
-                }
-            else:
-                redacted = redact_output(raw, redaction_list)
-                lines = redacted.split("\n")
-                files_update[fpath] = {
-                    "content": lines,
-                    "source": "output",
-                    "modified_at": now,
-                }
-
         update_dict: dict = {
             "messages": [
                 ToolMessage(
@@ -712,8 +1136,8 @@ def make_execute_python_code(db=None):
             ],
         }
 
-        if files_update:
-            update_dict["files"] = files_update
+        if new_files:
+            update_dict["files"] = new_files
 
         return Command(update=update_dict)
 

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -262,10 +262,27 @@ def exec_skill(
 def start_inotify_daemon(sandbox) -> None:
     """Start an inotifywait daemon that records file events to INOTIFY_JOURNAL_PATH.
 
-    Watches SANDBOX_WORKSPACE and SANDBOX_DATA recursively for create,
-    modify, close_write, open, and access events. Output format is
-    TSV: ``<event>\\t<path>\\t<unix_timestamp>``. The daemon runs in
-    the background (nohup + &) so process.exec returns immediately.
+    Watches SANDBOX_WORKSPACE and SANDBOX_DATA recursively for both
+    write-side events (create, modify, close_write, move, delete) and
+    read-side events (open, access). The read events are necessary
+    for the spec's cache-hit visibility on /data: when a previously-
+    downloaded /data file gets opened by this tool call's script, the
+    file shows up in the conversation's session view as something
+    this run touched, even though it wasn't written. Output format is
+    TSV ``<event>\\t<path>\\t<unix_timestamp>`` per event line.
+
+    The watched trees do NOT include Python's import paths (venvs and
+    the uv cache live under /root/.cache/uv and /root/.venv, outside
+    the watch set), so read events fire only for files the script
+    explicitly opens under /workspace or /data — exactly the signal
+    we want for "files this run touched."
+
+    Daemon redirect uses ``>>`` (O_APPEND) — every write atomically
+    seeks to end-of-file, which makes the truncate-in-place pattern
+    in ``drain_inotify_journal`` work correctly on subsequent drains.
+    Without O_APPEND, the daemon's FD position wouldn't follow a
+    truncate, and it would keep writing past offset 0 leaving sparse
+    holes in the journal that drain reads couldn't see.
 
     Best-effort: if inotifywait is missing or the watch can't start
     (e.g. inotify limits exhausted), logs and continues without
@@ -288,11 +305,13 @@ def start_inotify_daemon(sandbox) -> None:
         # Start the daemon. -m monitor mode (don't exit), -r recursive,
         # -e events. --format produces TSV; --timefmt %s makes the
         # timestamp a unix epoch second so we don't have to parse a
-        # human date string in the drain.
+        # human date string in the drain. >> opens with O_APPEND so
+        # every write atomically seeks to EOF — required for the
+        # truncate-in-place drain pattern to work without losing data.
         f"nohup inotifywait -mr "
-        f"-e create -e modify -e close_write -e open -e access "
+        f"-e create -e modify -e close_write -e move -e delete -e open -e access "
         f"--format '%e\\t%w%f\\t%T' --timefmt '%s' "
-        f"{workspace} {data} > {journal} 2>&1 &"
+        f"{workspace} {data} >> {journal} 2>&1 &"
     )
     response = exec_as_daytona(sandbox, init_cmd)
     if response.exit_code != 0:
@@ -307,7 +326,7 @@ def drain_inotify_journal(sandbox, default_source: str = "agent") -> dict[str, d
 
     Returns a dict keyed by logical path (state["files"] format — leading
     slash, no /workspace prefix; /data paths kept as-is). Each value is
-    {size, modified_at, source, last_event_type, first_seen}.
+    {size, modified_at, source, last_event, first_seen}.
 
     Path-to-source mapping:
       - Paths under /data → source = "data" regardless of caller.
@@ -318,24 +337,26 @@ def drain_inotify_journal(sandbox, default_source: str = "agent") -> dict[str, d
         runtime plumbing, not user-visible content. They never appear
         in state["files"].
 
-    Stats each surviving path to attach size and mtime. If the path
-    no longer exists (e.g. the script was a temp file deleted before
-    the drain ran), the entry is dropped.
+    Drain pattern: ``cat`` then truncate-in-place. The daemon was
+    started with O_APPEND (``>>``) so writes after truncate atomically
+    seek to the new end-of-file at offset 0 — the daemon's FD position
+    no longer matters. There's a tiny window between ``cat`` finishing
+    and ``: > journal`` running where the daemon could write events
+    that get truncated and lost; this is bounded by the few microseconds
+    between the two shell commands and is acceptable for "did this tool
+    call touch a file."
+
+    Path metadata is collected with a single ``stat`` call passing all
+    surviving paths as positional arguments, not one stat per path.
+    Paths that no longer exist (e.g. a temp file deleted before the
+    drain ran) are silently dropped — stat writes them to stderr (which
+    we discard) and continues with the rest.
     """
     journal = shlex.quote(INOTIFY_JOURNAL_PATH)
-    # Atomic read+truncate: rename to .read so any in-flight writes
-    # from the daemon append to a fresh (empty) journal we recreate.
-    # Then cat the renamed file. Best-effort — inotifywait keeps its
-    # FD open against the renamed inode and continues writing to it
-    # until we delete it, so events that happened during the rename
-    # window are preserved in the .read copy.
-    drain_cmd = (
-        f"if [ -f {journal} ]; then "
-        f"  mv {journal} {journal}.read 2>/dev/null && : > {journal}; "
-        f"  cat {journal}.read 2>/dev/null; "
-        f"  rm -f {journal}.read; "
-        f"fi"
-    )
+    # cat-then-truncate. Works correctly because the daemon writes
+    # with O_APPEND, so post-truncate writes seek to the new EOF (0)
+    # rather than the daemon's stale FD offset.
+    drain_cmd = f"if [ -f {journal} ]; then cat {journal} 2>/dev/null; : > {journal}; fi"
     response = exec_as_daytona(sandbox, drain_cmd)
     if response.exit_code != 0:
         return {}
@@ -361,9 +382,34 @@ def drain_inotify_journal(sandbox, default_source: str = "agent") -> dict[str, d
             entry["last_ts"] = ts
             entry["last_event"] = event
 
-    # Stat each path and build the state["files"] entries.
+    if not by_path:
+        return {}
+
+    # Single stat call covering every surviving path. stat prints one
+    # line per existing file to stdout; missing files go to stderr
+    # (which we discard) and stat exits non-zero only when no args
+    # could be processed at all. We always parse stdout regardless.
+    quoted_paths = " ".join(shlex.quote(p) for p in by_path)
+    stat_cmd = f"stat -c '%n|%s|%Y' {quoted_paths} 2>/dev/null || true"
+    stat_resp = exec_as_daytona(sandbox, stat_cmd)
+    stat_by_path: dict[str, tuple[int, float]] = {}
+    for line in stat_resp.result.splitlines():
+        # %n could in principle contain a literal '|' if a watched
+        # path embedded one; rsplit handles that by treating the last
+        # two '|' fields as size and mtime.
+        try:
+            name, size_s, mtime_s = line.rsplit("|", 2)
+            stat_by_path[name] = (int(size_s), float(mtime_s))
+        except ValueError:
+            continue
+
+    # Build the state["files"] entries from the intersection of
+    # journal events and successful stats.
     result: dict[str, dict] = {}
     for abs_path, agg in by_path.items():
+        if abs_path not in stat_by_path:
+            continue  # File was deleted between event and drain.
+        size, mtime = stat_by_path[abs_path]
         # Logical path: /workspace/foo → /foo, /data/bar stays /data/bar.
         if abs_path == SANDBOX_WORKSPACE or abs_path.startswith(SANDBOX_WORKSPACE + "/"):
             logical = abs_path[len(SANDBOX_WORKSPACE) :] or "/"
@@ -373,17 +419,6 @@ def drain_inotify_journal(sandbox, default_source: str = "agent") -> dict[str, d
             source = "data"
         else:
             # Out of scope — skip events from outside watched areas.
-            continue
-
-        # Stat to get size + mtime. If gone, skip.
-        stat_resp = exec_as_daytona(sandbox, f"stat -c '%s|%Y' {shlex.quote(abs_path)}")
-        if stat_resp.exit_code != 0:
-            continue
-        try:
-            size_s, mtime_s = stat_resp.result.strip().split("|")
-            size = int(size_s)
-            mtime = float(mtime_s)
-        except (ValueError, AttributeError):
             continue
 
         result[logical] = {

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -400,8 +400,10 @@ def _inotify_daemon_alive(sandbox) -> bool:
 
     Uses ``pgrep`` via the daytona-wrapped exec so the check sees the
     same process table the daemon was launched into. ``pgrep`` exits 0
-    when at least one match is found, 1 when none match. Any other
-    failure (pgrep missing, exec error) is treated as "unknown" and
+    when at least one match is found, 1 when none match. procps (which
+    provides pgrep) is installed in the sandbox image so the probe is a
+    real signal rather than a no-op exit 127. Any other outcome (probe
+    raised, or an unexpected exit code) is treated as "unknown" and
     reported as alive so we don't churn-restart on a transient probe
     failure — best-effort, never raises.
     """
@@ -410,10 +412,15 @@ def _inotify_daemon_alive(sandbox) -> bool:
     except Exception:
         logger.warning("inotify liveness probe failed; assuming daemon alive", exc_info=True)
         return True
-    # exit 1 = no matching process; exit 0 = found. Treat any other
-    # exit code (e.g. pgrep absent → 127) as "can't tell, leave it".
+    # exit 0 = at least one inotifywait process found → alive.
+    # exit 1 = no matching process → dead, restart.
+    # any other code (e.g. pgrep somehow absent → 127) = can't tell;
+    # log at debug and treat as alive so we don't thrash on restarts.
+    if response.exit_code == 0:
+        return True
     if response.exit_code == 1:
         return False
+    logger.debug("inotify liveness probe returned unexpected exit %s; assuming alive", response.exit_code)
     return True
 
 
@@ -448,26 +455,34 @@ def drain_inotify_journal(sandbox, default_source: str = "agent") -> dict[str, d
     drain ran) are silently dropped — stat writes them to stderr (which
     we discard) and continues with the rest.
     """
-    # The daemon is only started on first sandbox create. A reused
-    # sandbox may have lost it (process killed, sandbox restarted).
-    # Probe and restart before draining so tracking resumes; the events
-    # that fired while it was dead are simply missed, which is acceptable
-    # for "did this tool call touch a file." Best-effort — never raises.
-    if not _inotify_daemon_alive(sandbox):
-        logger.warning("inotify daemon not running; restarting before drain")
-        try:
-            start_inotify_daemon(sandbox)
-        except Exception:
-            logger.warning("Failed to restart inotify daemon before drain", exc_info=True)
-
     journal = shlex.quote(INOTIFY_JOURNAL_PATH)
-    # cat-then-truncate. Works correctly because the daemon writes
-    # with O_APPEND, so post-truncate writes seek to the new EOF (0)
-    # rather than the daemon's stale FD offset.
+    # Drain the existing journal FIRST (cat then truncate-in-place),
+    # before probing/restarting the daemon. A dead daemon may have left
+    # events in the journal from before it died; restarting first would
+    # run ``: > journal`` (in start_inotify_daemon) and wipe those events
+    # before we read them. Draining first captures them, then the restart
+    # below resumes tracking.
+    #
+    # cat-then-truncate works correctly because the daemon writes with
+    # O_APPEND, so post-truncate writes seek to the new EOF (0) rather
+    # than the daemon's stale FD offset.
     drain_cmd = f"if [ -f {journal} ]; then cat {journal} 2>/dev/null; : > {journal}; fi"
     response = exec_as_daytona(sandbox, drain_cmd)
     if response.exit_code != 0:
         return {}
+
+    # The daemon is only started on first sandbox create. A reused
+    # sandbox may have lost it (process killed, sandbox restarted).
+    # Probe and restart now that the pre-death journal has been drained;
+    # the events that fired while it was dead are simply missed, which is
+    # acceptable for "did this tool call touch a file." Best-effort —
+    # never raises.
+    if not _inotify_daemon_alive(sandbox):
+        logger.warning("inotify daemon not running; restarting after drain")
+        try:
+            start_inotify_daemon(sandbox)
+        except Exception:
+            logger.warning("Failed to restart inotify daemon after drain", exc_info=True)
 
     # Aggregate events per path. The daemon format is
     # ``<event>\t<path>\t<timestamp>``; the path field can itself contain
@@ -812,6 +827,8 @@ def _build_sandbox_image():
     - git installed (uv/pip can fetch VCS dependencies)
     - inotify-tools installed (the inotifywait binary the per-sandbox
       session-tracking daemon runs)
+    - procps installed (pgrep, used by the inotify liveness probe to
+      decide whether the daemon needs restarting)
     - uv installed via pip
     - daytona user created (the non-root identity all agent tool calls
       execute as via su -l wrapping)
@@ -828,7 +845,11 @@ def _build_sandbox_image():
     return (
         Image.debian_slim("3.12")
         .run_commands(
-            "apt-get update && apt-get install -y --no-install-recommends git inotify-tools "
+            # procps provides pgrep, which the inotify liveness probe
+            # (_inotify_daemon_alive) relies on. Without it the probe
+            # exits 127 and the daemon is reported alive forever, so a
+            # dead daemon would never be restarted.
+            "apt-get update && apt-get install -y --no-install-recommends git inotify-tools procps "
             "&& rm -rf /var/lib/apt/lists/*",
             # Non-root user the agent's tool calls execute as. -m creates
             # /home/daytona; -s sets the login shell; -r marks it a

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -713,19 +713,28 @@ def _is_safe_cleanup_path(homes_path: str) -> bool:
     """Return True only if ``homes_path`` is safe to recursively empty.
 
     Refuses an empty/relative path, ``/``, and any well-known system
-    directory. The delete is ``find <path> -mindepth 1 -delete``; pointing
-    it at one of these would wipe a system tree. A dedicated workspace
-    mount is an absolute path at least two levels deep (e.g. ``/workspace``
-    is one level but explicitly allowed via the not-forbidden check below;
-    anything shallower or system-owned is refused).
+    directory *or any path nested under one*. The delete is
+    ``find <path> -mindepth 1 -delete``; pointing it at one of these (or
+    a child like ``/etc/cron.d`` or ``/var/lib/postgresql``) would wipe a
+    system tree. A path is rejected when its normalized form equals a
+    forbidden root or is strictly under one. A dedicated workspace mount
+    (e.g. ``/workspace``, ``/mnt/homes``) lives outside every forbidden
+    root and is allowed.
     """
     if not homes_path:
         return False
     resolved = os.path.normpath(homes_path)
     if not resolved.startswith("/"):
         return False
-    if resolved in _FORBIDDEN_CLEANUP_PATHS:
-        return False
+    for root in _FORBIDDEN_CLEANUP_PATHS:
+        if resolved == root:
+            return False
+        # ``/`` is a forbidden root but its "under" prefix would be "//"
+        # and would reject every absolute path; the exact-match check
+        # above already covers it. For every other root, reject paths
+        # strictly nested beneath it (e.g. /etc/cron.d under /etc).
+        if root != "/" and resolved.startswith(root + "/"):
+            return False
     return True
 
 

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -79,6 +79,12 @@ SANDBOX_SKILLS_DIR = "/skills"
 # log file ownership consistent).
 INOTIFY_JOURNAL_PATH = "/tmp/inotify.log"
 
+# Where inotifywait's own stderr (diagnostics, watch-limit errors) is
+# written. Kept separate from the event journal so error text never
+# pollutes the TSV event stream the drain parses, and so a watch-limit
+# failure can be detected by inspecting this file at startup.
+INOTIFY_STDERR_PATH = "/tmp/inotify.err"
+
 
 def _normalize_sandbox_upload_path(path: str) -> str:
     """Convert a logical credential-file path to the form Daytona's fs.upload_file expects.
@@ -321,23 +327,36 @@ def start_inotify_daemon(sandbox) -> None:
     the per-sandbox file ownership.
     """
     journal = shlex.quote(INOTIFY_JOURNAL_PATH)
+    errlog = shlex.quote(INOTIFY_STDERR_PATH)
     workspace = shlex.quote(SANDBOX_WORKSPACE)
     data = shlex.quote(SANDBOX_DATA)
     # Truncate any previous journal (daemon may have left one if a
     # different conversation reused the same sandbox name — shouldn't
-    # happen with our per-thread sandboxes, but defensive).
+    # happen with our per-thread sandboxes, but defensive). A recursive
+    # ``-mr`` watch installs one watch per directory; a deep /data tree
+    # can exhaust the kernel's per-user max_user_watches limit, on which
+    # inotifywait prints an error to stderr and exits during setup. We
+    # send events (stdout) to the journal and diagnostics (stderr) to a
+    # separate error file, then briefly probe so the watch-limit failure
+    # is detected and logged instead of silently disabling tracking.
     init_cmd = (
-        f": > {journal}; "
+        f": > {journal}; : > {errlog}; "
         # Start the daemon. -m monitor mode (don't exit), -r recursive,
         # -e events. --format produces TSV; --timefmt %s makes the
         # timestamp a unix epoch second so we don't have to parse a
-        # human date string in the drain. >> opens with O_APPEND so
-        # every write atomically seeks to EOF — required for the
+        # human date string in the drain. >> on stdout opens with O_APPEND
+        # so every write atomically seeks to EOF — required for the
         # truncate-in-place drain pattern to work without losing data.
+        # stderr goes to its own file, not the journal.
         f"nohup inotifywait -mr "
         f"-e create -e modify -e close_write -e move -e delete -e open -e access "
         f"--format '%e\\t%w%f\\t%T' --timefmt '%s' "
-        f"{workspace} {data} >> {journal} 2>&1 &"
+        f"{workspace} {data} >> {journal} 2>> {errlog} & "
+        # Give inotifywait a moment to either establish all watches or
+        # fail setting them up, then report what happened on stdout.
+        f"sleep 1; "
+        f"if pgrep -x inotifywait >/dev/null 2>&1; then echo INOTIFY_RUNNING; "
+        f"else echo INOTIFY_DEAD; fi; cat {errlog} 2>/dev/null"
     )
     response = exec_as_daytona(sandbox, init_cmd)
     if response.exit_code != 0:
@@ -345,6 +364,29 @@ def start_inotify_daemon(sandbox) -> None:
             "Failed to start inotify daemon (session tracking disabled): %s",
             response.result,
         )
+        return
+
+    out = response.result or ""
+    # Watch-limit exhaustion: inotifywait prints a message mentioning the
+    # inotify watch limit (wording varies across versions, but always
+    # references the limit / max_user_watches) and exits during setup.
+    lowered = out.lower()
+    hit_watch_limit = "inotify" in lowered and (
+        "upgrade" in lowered or "watch limit" in lowered or "max_user_watches" in lowered or "no space left" in lowered
+    )
+    if "INOTIFY_DEAD" in out:
+        if hit_watch_limit:
+            logger.warning(
+                "inotify daemon exited at startup — kernel watch limit (max_user_watches) "
+                "exhausted on the recursive /data watch; session tracking disabled. "
+                "Raise fs.inotify.max_user_watches or narrow the watched tree. Detail: %s",
+                out.strip(),
+            )
+        else:
+            logger.warning(
+                "inotify daemon exited at startup (session tracking disabled): %s",
+                out.strip(),
+            )
 
 
 def _inotify_daemon_alive(sandbox) -> bool:

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -607,6 +607,53 @@ def _build_volume_mounts(thread_id: str):
     return mounts or None
 
 
+# Top-level directories that must never be the target of the recursive
+# workspace delete. A misconfigured DAYTONA_HOMES_MOUNT_PATH (e.g. "/"
+# or unset-to-empty resolving somewhere unexpected) would otherwise turn
+# `find <path> -mindepth 1 -delete` into a wipe of a system tree.
+_FORBIDDEN_CLEANUP_PATHS = frozenset(
+    {
+        "/",
+        "/bin",
+        "/boot",
+        "/dev",
+        "/etc",
+        "/home",
+        "/lib",
+        "/lib64",
+        "/proc",
+        "/root",
+        "/run",
+        "/sbin",
+        "/srv",
+        "/sys",
+        "/tmp",
+        "/usr",
+        "/var",
+    }
+)
+
+
+def _is_safe_cleanup_path(homes_path: str) -> bool:
+    """Return True only if ``homes_path`` is safe to recursively empty.
+
+    Refuses an empty/relative path, ``/``, and any well-known system
+    directory. The delete is ``find <path> -mindepth 1 -delete``; pointing
+    it at one of these would wipe a system tree. A dedicated workspace
+    mount is an absolute path at least two levels deep (e.g. ``/workspace``
+    is one level but explicitly allowed via the not-forbidden check below;
+    anything shallower or system-owned is refused).
+    """
+    if not homes_path:
+        return False
+    resolved = os.path.normpath(homes_path)
+    if not resolved.startswith("/"):
+        return False
+    if resolved in _FORBIDDEN_CLEANUP_PATHS:
+        return False
+    return True
+
+
 def cleanup_thread_workspace(thread_id: str) -> None:
     """Remove a thread's subpath from the homes volume.
 
@@ -633,6 +680,14 @@ def cleanup_thread_workspace(thread_id: str) -> None:
         return
 
     homes_path = os.environ.get(_HOMES_MOUNT_PATH_ENV, "").strip() or SANDBOX_WORKSPACE
+    if not _is_safe_cleanup_path(homes_path):
+        logger.error(
+            "Refusing workspace cleanup for thread %s: homes mount path %r is not a "
+            "dedicated workspace mount (would recursively delete a system tree)",
+            thread_id,
+            homes_path,
+        )
+        return
     rm_cmd = f"find {shlex.quote(homes_path)} -mindepth 1 -delete"
 
     # Path 1: reuse the active per-thread sandbox if alive.

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -128,26 +128,40 @@ def workspace_path(logical_path: str) -> str:
     ``ValueError`` so the caller can map it to a 4xx without performing
     any filesystem access. This is the single choke point feeding both
     the stat/read and the migration write.
+
+    Cross-volume aliasing is also rejected: a ``/data``-prefixed logical
+    input must resolve under SANDBOX_DATA, and a non-``/data`` input must
+    resolve under SANDBOX_WORKSPACE. A path like ``/data/../workspace/x``
+    would lexically normalize into /workspace, silently moving a
+    "/data"-keyed file into the workspace namespace and breaking the
+    state["files"] key invariant. The resolved root must match the root
+    implied by the logical prefix; a mismatch raises ``ValueError``.
     """
     if logical_path == SANDBOX_DATA or logical_path.startswith(SANDBOX_DATA + "/"):
         candidate = logical_path
+        expects_data = True
     else:
         rel = logical_path.lstrip("/")
         candidate = f"{SANDBOX_WORKSPACE}/{rel}"
+        expects_data = False
 
     # Collapse ``..``/``.`` and redundant separators, then confirm the
     # result still lives under one of the two permitted roots. normpath
-    # is enough because there are no symlinks in the logical namespace;
-    # the symlink concern is moot since these roots are mountpoint-s3.
+    # is enough for the lexical traversal check here; the symlink-escape
+    # concern is handled separately by the in-sandbox realpath guard in
+    # the read/write helpers.
     resolved = os.path.normpath(candidate)
-    allowed = (
-        resolved == SANDBOX_WORKSPACE
-        or resolved.startswith(SANDBOX_WORKSPACE + "/")
-        or resolved == SANDBOX_DATA
-        or resolved.startswith(SANDBOX_DATA + "/")
-    )
-    if not allowed:
+    under_data = resolved == SANDBOX_DATA or resolved.startswith(SANDBOX_DATA + "/")
+    under_workspace = resolved == SANDBOX_WORKSPACE or resolved.startswith(SANDBOX_WORKSPACE + "/")
+    if not (under_data or under_workspace):
         raise ValueError(f"path escapes workspace/data roots: {logical_path!r}")
+    # Cross-volume aliasing: the resolved root must match the root the
+    # logical prefix implied. A /data input that normalizes into
+    # /workspace (or vice versa) is rejected, not silently re-rooted.
+    if expects_data and not under_data:
+        raise ValueError(f"/data path resolves outside the data root: {logical_path!r}")
+    if not expects_data and not under_workspace:
+        raise ValueError(f"workspace path resolves outside the workspace root: {logical_path!r}")
     return resolved
 
 

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -187,21 +187,27 @@ def list_workspace_files(sandbox, abs_dir: str) -> list[dict]:
     recursively. Returns empty list if the directory does not exist or is empty.
     """
     quoted = shlex.quote(abs_dir)
-    # Use find + stat, format as TSV for safe parsing
-    cmd = f"test -d {quoted} || exit 0; find {quoted} -type f -printf '%p\\t%s\\t%T@\\n' 2>/dev/null"
+    # NUL-separated records: find emits ``<path>\0<size>\0<mtime>\0`` per
+    # file. NUL is the one byte that cannot appear in a POSIX filename, so
+    # this parses correctly even when a filename contains tabs or newlines
+    # (which a TSV/line-based scheme would silently drop or corrupt).
+    cmd = f"test -d {quoted} || exit 0; find {quoted} -type f -printf '%p\\0%s\\0%T@\\0' 2>/dev/null"
     response = sandbox.process.exec(cmd)
     if response.exit_code != 0:
         return []
     out: list[dict] = []
-    for line in response.result.splitlines():
-        parts = line.split("\t")
-        if len(parts) != 3:
+    # Split on NUL and consume in groups of three; the trailing
+    # separator leaves an empty final element we ignore.
+    fields = response.result.split("\0")
+    for i in range(0, len(fields) - 2, 3):
+        path, size_s, mtime_s = fields[i], fields[i + 1], fields[i + 2]
+        if not path:
             continue
-        path, size_s, mtime_s = parts
         try:
             size = int(size_s)
             mtime = float(mtime_s)
         except ValueError:
+            logger.warning("Skipping unparseable find record for %r in %s", path, abs_dir)
             continue
         out.append(
             {
@@ -463,13 +469,25 @@ def drain_inotify_journal(sandbox, default_source: str = "agent") -> dict[str, d
     if response.exit_code != 0:
         return {}
 
-    # Aggregate events per path.
+    # Aggregate events per path. The daemon format is
+    # ``<event>\t<path>\t<timestamp>``; the path field can itself contain
+    # tabs, so peel off the event (first field) and timestamp (last field)
+    # and treat everything between as the path rather than requiring
+    # exactly three tab-separated fields. An embedded NEWLINE in a
+    # filename still splits the record across lines (inotifywait's
+    # --format has no NUL option), so those lines are logged as dropped
+    # rather than silently skipped.
     by_path: dict[str, dict] = {}
     for line in response.result.splitlines():
-        parts = line.split("\t")
-        if len(parts) != 3:
+        head, sep, rest = line.partition("\t")
+        if not sep:
+            logger.warning("Dropping malformed inotify journal line (no field separator): %r", line)
             continue
-        event, path, ts_s = parts
+        path, sep2, ts_s = rest.rpartition("\t")
+        if not sep2:
+            logger.warning("Dropping malformed inotify journal line (missing timestamp field): %r", line)
+            continue
+        event = head
         if not path or not path.startswith("/"):
             continue
         # Filter skill-internal paths.

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -1195,7 +1195,11 @@ def make_execute_python_code(db=None):
 
             code_b64 = base64.b64encode(code.encode("utf-8")).decode("ascii")
             run_cmd = f"echo {shlex.quote(code_b64)} | base64 -d | python3"
-            response = exec_as_daytona(sandbox, run_cmd, env=env_vars or None)
+            # Run in /workspace so relative-path writes (e.g. open("out.csv"))
+            # land on the persistent volume and show up in the session view,
+            # matching run_file/exec_skill. Without cwd, su -l starts the
+            # shell at daytona's $HOME and outputs land off the volume.
+            response = exec_as_daytona(sandbox, run_cmd, cwd=SANDBOX_WORKSPACE, env=env_vars or None)
 
             # Pick up any new files the script wrote, via the inotify
             # journal. The drain returns logical paths with proper

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -347,6 +347,28 @@ def start_inotify_daemon(sandbox) -> None:
         )
 
 
+def _inotify_daemon_alive(sandbox) -> bool:
+    """Return True if an inotifywait process is running in the sandbox.
+
+    Uses ``pgrep`` via the daytona-wrapped exec so the check sees the
+    same process table the daemon was launched into. ``pgrep`` exits 0
+    when at least one match is found, 1 when none match. Any other
+    failure (pgrep missing, exec error) is treated as "unknown" and
+    reported as alive so we don't churn-restart on a transient probe
+    failure — best-effort, never raises.
+    """
+    try:
+        response = exec_as_daytona(sandbox, "pgrep -x inotifywait")
+    except Exception:
+        logger.warning("inotify liveness probe failed; assuming daemon alive", exc_info=True)
+        return True
+    # exit 1 = no matching process; exit 0 = found. Treat any other
+    # exit code (e.g. pgrep absent → 127) as "can't tell, leave it".
+    if response.exit_code == 1:
+        return False
+    return True
+
+
 def drain_inotify_journal(sandbox, default_source: str = "agent") -> dict[str, dict]:
     """Read and truncate the inotify journal, return aggregated path metadata.
 
@@ -378,6 +400,18 @@ def drain_inotify_journal(sandbox, default_source: str = "agent") -> dict[str, d
     drain ran) are silently dropped — stat writes them to stderr (which
     we discard) and continues with the rest.
     """
+    # The daemon is only started on first sandbox create. A reused
+    # sandbox may have lost it (process killed, sandbox restarted).
+    # Probe and restart before draining so tracking resumes; the events
+    # that fired while it was dead are simply missed, which is acceptable
+    # for "did this tool call touch a file." Best-effort — never raises.
+    if not _inotify_daemon_alive(sandbox):
+        logger.warning("inotify daemon not running; restarting before drain")
+        try:
+            start_inotify_daemon(sandbox)
+        except Exception:
+            logger.warning("Failed to restart inotify daemon before drain", exc_info=True)
+
     journal = shlex.quote(INOTIFY_JOURNAL_PATH)
     # cat-then-truncate. Works correctly because the daemon writes
     # with O_APPEND, so post-truncate writes seek to the new EOF (0)

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -112,11 +112,37 @@ def workspace_path(logical_path: str) -> str:
     The two-prefix scheme keeps state["files"] keys unambiguous: a file on
     the data volume is identified by its ``/data/...`` path, a file in
     the workspace by a path that does not start with ``/data/``.
+
+    Path traversal is rejected: the resolved absolute path must stay
+    strictly under SANDBOX_WORKSPACE or SANDBOX_DATA. A logical path
+    containing ``..`` segments (e.g. ``/../etc/passwd`` or
+    ``/data/../../etc/x``) would otherwise normalize to a root-owned file
+    that ``read_workspace_file``/``write_workspace_file`` run as root.
+    Mirrors ``_validate_skill_path``'s rejection style; raises
+    ``ValueError`` so the caller can map it to a 4xx without performing
+    any filesystem access. This is the single choke point feeding both
+    the stat/read and the migration write.
     """
     if logical_path == SANDBOX_DATA or logical_path.startswith(SANDBOX_DATA + "/"):
-        return logical_path
-    rel = logical_path.lstrip("/")
-    return f"{SANDBOX_WORKSPACE}/{rel}"
+        candidate = logical_path
+    else:
+        rel = logical_path.lstrip("/")
+        candidate = f"{SANDBOX_WORKSPACE}/{rel}"
+
+    # Collapse ``..``/``.`` and redundant separators, then confirm the
+    # result still lives under one of the two permitted roots. normpath
+    # is enough because there are no symlinks in the logical namespace;
+    # the symlink concern is moot since these roots are mountpoint-s3.
+    resolved = os.path.normpath(candidate)
+    allowed = (
+        resolved == SANDBOX_WORKSPACE
+        or resolved.startswith(SANDBOX_WORKSPACE + "/")
+        or resolved == SANDBOX_DATA
+        or resolved.startswith(SANDBOX_DATA + "/")
+    )
+    if not allowed:
+        raise ValueError(f"path escapes workspace/data roots: {logical_path!r}")
+    return resolved
 
 
 def write_workspace_file(sandbox, abs_path: str, content: bytes) -> None:

--- a/src/rhiza_agents/agents/tools/sandbox.py
+++ b/src/rhiza_agents/agents/tools/sandbox.py
@@ -151,13 +151,74 @@ def workspace_path(logical_path: str) -> str:
     return resolved
 
 
+def _is_contained(real_path: str) -> bool:
+    """True if ``real_path`` is at or under SANDBOX_WORKSPACE / SANDBOX_DATA.
+
+    ``real_path`` is expected to already be a symlink-resolved absolute
+    path (the output of ``realpath`` in the sandbox). The same containment
+    predicate used by ``workspace_path``'s lexical check, applied here to
+    the real resolved path.
+    """
+    return (
+        real_path == SANDBOX_WORKSPACE
+        or real_path.startswith(SANDBOX_WORKSPACE + "/")
+        or real_path == SANDBOX_DATA
+        or real_path.startswith(SANDBOX_DATA + "/")
+    )
+
+
+def _assert_realpath_contained(sandbox, abs_path: str, *, resolve_parent: bool) -> None:
+    """Resolve ``abs_path`` in the sandbox and reject symlink escapes.
+
+    ``workspace_path``'s ``normpath`` check is lexical only: it cannot see
+    symlinks, which live in the sandbox filesystem. The agent can write to
+    /workspace and /data (HITL-approved ``execute_python_code``), so it
+    could plant a symlink whose target escapes the roots; a root-level
+    read/write would then follow it. This resolves the REAL path inside
+    the sandbox and verifies it still lands under /workspace or /data,
+    raising ``ValueError`` on escape so the caller performs no read/write.
+
+    ``resolve_parent`` controls what gets resolved:
+
+      - ``False`` (reads): resolve ``abs_path`` itself with ``realpath -m``.
+        ``-m`` resolves every existing symlink in the chain and treats a
+        missing final component lexically, so it never fails on a not-yet-
+        existing file (the read's own ``test -f`` gates existence) while
+        still following a symlinked file or a symlinked parent to its real
+        target.
+      - ``True`` (writes): resolve the parent directory's real path. The
+        existing components — including any symlinked directory in the
+        chain — determine where the write actually lands.
+
+    ``realpath -m`` does not fail for a missing path, so a non-zero exit
+    here means the resolver itself failed; we treat that as unverifiable
+    and raise rather than letting the path through.
+    """
+    target = os.path.dirname(abs_path) or "/" if resolve_parent else abs_path
+    quoted = shlex.quote(target)
+    response = sandbox.process.exec(f"realpath -m -- {quoted}")
+    if response.exit_code != 0:
+        raise ValueError(f"could not resolve real path for {abs_path!r}")
+    real = response.result.strip()
+    if not real:
+        raise ValueError(f"empty realpath for {abs_path!r}")
+    if not _is_contained(real):
+        raise ValueError(f"path escapes workspace/data roots via symlink: {abs_path!r} -> {real!r}")
+
+
 def write_workspace_file(sandbox, abs_path: str, content: bytes) -> None:
     """Write bytes to an absolute path in the sandbox.
 
     fs.upload_file resolves relative-to-cwd; absolute paths are not
     respected. Use shell + base64 to write to arbitrary absolute paths.
     Caller is responsible for shell-safe ``abs_path`` (this helper quotes it).
+
+    Before writing, the parent directory's real (symlink-resolved) path is
+    verified to stay under /workspace or /data; a symlinked directory in
+    the chain that escapes the roots raises ``ValueError`` and no write
+    runs. Defense in depth on top of ``workspace_path``'s lexical check.
     """
+    _assert_realpath_contained(sandbox, abs_path, resolve_parent=True)
     b64 = base64.b64encode(content).decode("ascii")
     quoted = shlex.quote(abs_path)
     parent = os.path.dirname(abs_path) or "/"
@@ -172,7 +233,13 @@ def read_workspace_file(sandbox, abs_path: str) -> bytes:
 
     fs.download_file is relative-to-cwd; this is the absolute-path equivalent.
     Raises FileNotFoundError if the path does not exist.
+
+    Before reading, the file's real (symlink-resolved) path is verified to
+    stay under /workspace or /data; a symlink whose target escapes the
+    roots raises ``ValueError`` and no read runs. Defense in depth on top
+    of ``workspace_path``'s lexical check.
     """
+    _assert_realpath_contained(sandbox, abs_path, resolve_parent=False)
     quoted = shlex.quote(abs_path)
     response = sandbox.process.exec(f"test -f {quoted} && base64 -w 0 {quoted}")
     if response.exit_code != 0:

--- a/src/rhiza_agents/agents/tools/skills.py
+++ b/src/rhiza_agents/agents/tools/skills.py
@@ -12,8 +12,8 @@ Each skill registers as a LangChain tool using progressive disclosure:
 import json
 import logging
 import re
+import shlex
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
 
 import yaml
 from langchain_core.messages import ToolMessage
@@ -252,6 +252,17 @@ def requires_sandbox(skill_record: dict) -> bool:
     return False
 
 
+def update_with_error(update: dict, tool_call_id: str, msg: str) -> Command:
+    """Append an error ToolMessage to a Command-update dict and wrap as Command.
+
+    Used by skill activation when something goes wrong after the prompt has
+    already been queued — keeps the prompt in the response while making the
+    failure visible to the agent.
+    """
+    update.setdefault("messages", []).append(ToolMessage(content=msg, tool_call_id=tool_call_id, status="error"))
+    return Command(update=update)
+
+
 def create_skill_tool(skill_record: dict) -> StructuredTool:
     """Create a LangChain tool for a skill.
 
@@ -272,27 +283,93 @@ def create_skill_tool(skill_record: dict) -> StructuredTool:
     script_path_prefix = f"/skills/{parsed.name}/scripts"
 
     async def _activate(*, runtime: ToolRuntime) -> Command:
-        """Activate this skill and load any bundled scripts into file state."""
+        """Activate this skill and install any bundled scripts to /skills/.
+
+        Scripts are written to ``/skills/<name>/scripts/<filename>``
+        via shell + base64 from the unwrapped (root) exec path, then
+        chowned root:root with mode 0644. The agent runs as daytona
+        and can read+execute but cannot modify these files — POSIX
+        permissions enforce this because /skills/ is on the regular
+        container filesystem, not a volume.
+
+        Skill scripts are not added to state["files"] — they don't
+        belong in conversation state. The activation response message
+        tells the agent which paths to invoke via run_file.
+
+        Namespacing by skill name prevents filename collisions across
+        skills (e.g. multiple fetchers each shipping a ``fetch.py``).
+        """
+        import asyncio
+        import base64
+
+        from .sandbox import _get_or_create_sandbox, is_sandbox_available
+
         prompt = _build_activation_response(record)
         update: dict = {"messages": [ToolMessage(content=prompt, tool_call_id=runtime.tool_call_id)]}
-        if scripts:
-            now = datetime.now(UTC).isoformat()
-            files_update: dict = {}
+        if not scripts:
+            return Command(update=update)
+
+        if not is_sandbox_available():
+            # Skill activation needs a sandbox to install scripts.
+            # Skills that bundle scripts should not have been routed
+            # to a non-sandbox agent (graph build filters by
+            # requires_sandbox), but be defensive.
+            update["messages"].append(
+                ToolMessage(
+                    content=(
+                        f"Skill {parsed.name!r} bundles scripts but the sandbox is "
+                        "unavailable (DAYTONA_API_KEY not set). Scripts not installed; "
+                        "run_file will not find them."
+                    ),
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            )
+            return Command(update=update)
+
+        thread_id = (
+            (runtime.config or {}).get("configurable", {}).get("thread_id", "default")
+            if hasattr(runtime, "config")
+            else "default"
+        )
+
+        def _install_all():
+            sandbox = _get_or_create_sandbox(thread_id)
+            # script_path_prefix is "/skills/<skill-name>/scripts" so
+            # abs_path is "/skills/<skill-name>/scripts/<file>".
             for filename, content in scripts.items():
-                # Content is stored as a single string; split into lines to
-                # match the shape used by write_file.
                 if isinstance(content, list):
-                    lines = content
+                    text = "\n".join(content)
                 else:
-                    lines = str(content).split("\n")
-                files_update[f"{script_path_prefix}/{filename}"] = {
-                    "content": lines,
-                    "source": "skill",
-                    "skill_id": skill_id,
-                    "created_at": now,
-                    "modified_at": now,
-                }
-            update["files"] = files_update
+                    text = str(content)
+                abs_path = f"{script_path_prefix}/{filename}"
+                parent = abs_path.rsplit("/", 1)[0]
+                # Write via shell + base64 to an absolute path. The
+                # exec runs as root (unwrapped) so files land owned
+                # root:root; chown is defensive in case Daytona ever
+                # changes the unwrapped-exec identity. chmod 0644
+                # makes the file world-readable / executable but not
+                # writable — daytona reads + execs but cannot modify.
+                b64 = base64.b64encode(text.encode("utf-8")).decode("ascii")
+                sandbox.process.exec(
+                    f"mkdir -p {shlex.quote(parent)} && "
+                    f"chmod 0755 {shlex.quote(parent)} && "
+                    f"echo {shlex.quote(b64)} | base64 -d > {shlex.quote(abs_path)} && "
+                    f"chown root:root {shlex.quote(abs_path)} && "
+                    f"chmod 0644 {shlex.quote(abs_path)}"
+                )
+
+        try:
+            await asyncio.to_thread(_install_all)
+        except Exception as e:
+            logger.warning("Failed to install skill scripts for %s", parsed.name, exc_info=True)
+            update["messages"].append(
+                ToolMessage(
+                    content=f"Failed to install skill scripts for {parsed.name!r}: {e}",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            )
         return Command(update=update)
 
     tool = StructuredTool.from_function(

--- a/src/rhiza_agents/routes/chat.py
+++ b/src/rhiza_agents/routes/chat.py
@@ -327,14 +327,19 @@ async def stream_chat_message(
                                             tool=tc["name"],
                                             tool_args=str(tc["args"])[:500],
                                         )
-                                        # Emit file data immediately so the UI can
-                                        # show the file before the checkpoint saves
-                                        if tc["name"] == "write_file" and isinstance(tc.get("args"), dict):
-                                            file_data = {
-                                                "path": tc["args"].get("path", ""),
-                                                "content": tc["args"].get("content", ""),
-                                            }
-                                            yield f"event: file_written\ndata: {json.dumps(file_data)}\n\n"
+                                        # write_file is commented out under
+                                        # the zero-trust model. The
+                                        # file_written SSE emission is
+                                        # preserved here as a comment so
+                                        # the streaming flow can be
+                                        # revived alongside write_file
+                                        # if the trust model changes.
+                                        # if tc["name"] == "write_file" and isinstance(tc.get("args"), dict):
+                                        #     file_data = {
+                                        #         "path": tc["args"].get("path", ""),
+                                        #         "content": tc["args"].get("content", ""),
+                                        #     }
+                                        #     yield f"event: file_written\ndata: {json.dumps(file_data)}\n\n"
                                 # Tool results from ToolMessages
                                 if isinstance(msg, ToolMessage):
                                     if msg.name and msg.name.startswith(("transfer_to_", "transfer_back_to_")):

--- a/src/rhiza_agents/routes/chat.py
+++ b/src/rhiza_agents/routes/chat.py
@@ -327,19 +327,6 @@ async def stream_chat_message(
                                             tool=tc["name"],
                                             tool_args=str(tc["args"])[:500],
                                         )
-                                        # write_file is commented out under
-                                        # the zero-trust model. The
-                                        # file_written SSE emission is
-                                        # preserved here as a comment so
-                                        # the streaming flow can be
-                                        # revived alongside write_file
-                                        # if the trust model changes.
-                                        # if tc["name"] == "write_file" and isinstance(tc.get("args"), dict):
-                                        #     file_data = {
-                                        #         "path": tc["args"].get("path", ""),
-                                        #         "content": tc["args"].get("content", ""),
-                                        #     }
-                                        #     yield f"event: file_written\ndata: {json.dumps(file_data)}\n\n"
                                 # Tool results from ToolMessages
                                 if isinstance(msg, ToolMessage):
                                     if msg.name and msg.name.startswith(("transfer_to_", "transfer_back_to_")):
@@ -378,10 +365,8 @@ async def stream_chat_message(
                                         html_url = extract_chart_url(msg.content)
                                         if html_url:
                                             yield f"event: chart\ndata: {json.dumps({'url': html_url})}\n\n"
-                                    # Emit files_changed for run_file results
-                                    # (write_file uses file_written from tool_start instead,
-                                    # since files_changed triggers loadFiles which overwrites
-                                    # the immediate file display before checkpoint saves)
+                                    # Emit files_changed after run_file so the
+                                    # client refetches the file list.
                                     if msg.name == "run_file":
                                         yield f"event: files_changed\ndata: {json.dumps({})}\n\n"
 
@@ -607,14 +592,6 @@ async def resume_chat(
                                         tool=tc["name"],
                                         tool_args=str(tc["args"])[:500],
                                     )
-                                    # Emit file data immediately so the UI can
-                                    # show the file before the checkpoint saves
-                                    if tc["name"] == "write_file" and isinstance(tc.get("args"), dict):
-                                        file_data = {
-                                            "path": tc["args"].get("path", ""),
-                                            "content": tc["args"].get("content", ""),
-                                        }
-                                        yield f"event: file_written\ndata: {json.dumps(file_data)}\n\n"
                             if isinstance(msg, ToolMessage):
                                 if msg.name and msg.name.startswith(("transfer_to_", "transfer_back_to_")):
                                     continue

--- a/src/rhiza_agents/routes/conversations.py
+++ b/src/rhiza_agents/routes/conversations.py
@@ -148,10 +148,14 @@ async def delete_conversation(request: Request, conversation_id: str, user: dict
         raise HTTPException(status_code=403, detail="You do not own this conversation")
 
     # DB row first so a partial failure leaves no orphan; sandbox/volume
-    # cleanup is best-effort and logged on failure.
+    # cleanup is best-effort and logged on failure. Workspace cleanup
+    # runs BEFORE the sandbox kill so cleanup_thread_workspace can reuse
+    # the active sandbox to do the rm — saves a ~5–15s sandbox-create.
+    # If the sandbox is already gone (idle-cleaned), the helper spins up
+    # a temp sandbox to perform the cleanup.
     await db.delete_conversation(conversation_id, user_id)
-    await asyncio.to_thread(cleanup_sandbox, conversation_id)
     await cleanup_thread_workspace_async(conversation_id)
+    await asyncio.to_thread(cleanup_sandbox, conversation_id)
     return {"status": "deleted"}
 
 

--- a/src/rhiza_agents/routes/conversations.py
+++ b/src/rhiza_agents/routes/conversations.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 import logging
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
@@ -29,6 +30,35 @@ from ..messages import build_name_mappings, process_messages
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["conversations"])
+
+
+def _content_disposition_attachment(filename: str) -> str:
+    """Build a Content-Disposition header value safe for any filename.
+
+    Per RFC 6266 + RFC 5987: emit ``filename="<ascii>"`` for old clients
+    plus ``filename*=UTF-8''<pct-encoded>`` for the modern unicode form.
+    Control characters (CR/LF in particular) are stripped before either
+    form is produced so the result cannot break out of the header into
+    a new header — closing CVE-style injection where a filename like
+    ``foo"; X-Injected: bar.txt`` would otherwise add a header.
+
+    Filenames are sourced from sandbox paths controlled either by a
+    skill's output or by the agent itself; this helper makes both
+    sources safe to render verbatim in the response header.
+    """
+    # Drop ASCII control characters (\x00-\x1F, \x7F). These are what
+    # actually let an attacker inject a new header line.
+    safe = "".join(c for c in filename if 32 <= ord(c) < 127 or ord(c) > 127)
+    if not safe:
+        safe = "file"
+    # ASCII-only fallback for ancient clients. Non-ASCII characters
+    # become "?" (replace error handler), then any remaining quotes /
+    # backslashes get escaped per RFC 6266 grammar.
+    ascii_only = safe.encode("ascii", errors="replace").decode("ascii")
+    ascii_escaped = ascii_only.replace("\\", "\\\\").replace('"', '\\"')
+    # RFC 5987 percent-encoded form preserves the original unicode.
+    pct_encoded = quote(safe, safe="")
+    return f"attachment; filename=\"{ascii_escaped}\"; filename*=UTF-8''{pct_encoded}"
 
 
 async def _get_mcp_tools_for_owner(request: Request, owner_id: str) -> tuple[dict[str, list], dict[str, str]]:
@@ -378,5 +408,5 @@ async def download_conversation_file(
     return Response(
         content=content_bytes,
         media_type="application/octet-stream",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        headers={"Content-Disposition": _content_disposition_attachment(filename)},
     )

--- a/src/rhiza_agents/routes/conversations.py
+++ b/src/rhiza_agents/routes/conversations.py
@@ -1,13 +1,17 @@
 """Conversation list/delete, messages, and files API routes."""
 
 import asyncio
+import base64
 import json
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import Response
 
 from ..agents.registry import get_default_configs, merge_configs
 from ..agents.supervisor import get_agent_graph
-from ..agents.tools.sandbox import cleanup_sandbox
+from ..agents.tools.files import fetch_file_content, list_thread_files
+from ..agents.tools.sandbox import cleanup_sandbox, cleanup_thread_workspace_async
 from ..db.models import AgentConfig
 from ..deps import (
     _skill_cache,
@@ -21,6 +25,8 @@ from ..deps import (
     require_auth,
 )
 from ..messages import build_name_mappings, process_messages
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["conversations"])
 
@@ -94,11 +100,28 @@ async def list_conversations(request: Request, user: dict = Depends(require_auth
 
 @router.delete("/api/conversations/{conversation_id}")
 async def delete_conversation(request: Request, conversation_id: str, user: dict = Depends(require_auth)):
-    """Delete a conversation and clean up its sandbox."""
+    """Delete a conversation and clean up its sandbox + workspace.
+
+    Only the conversation owner can delete. Non-owner requests get 404
+    (do not leak existence beyond what the read-only access allows) /
+    403 (when ownership mismatches a known conversation). The owner check
+    happens before any side effects so a non-owner request cannot disrupt
+    the owner's running sandbox.
+    """
     db = get_db(request)
     user_id = get_user_id(request)
+
+    conversation = await db.get_conversation_by_id(conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    if conversation.get("user_id") != user_id:
+        raise HTTPException(status_code=403, detail="You do not own this conversation")
+
+    # DB row first so a partial failure leaves no orphan; sandbox/volume
+    # cleanup is best-effort and logged on failure.
     await db.delete_conversation(conversation_id, user_id)
     await asyncio.to_thread(cleanup_sandbox, conversation_id)
+    await cleanup_thread_workspace_async(conversation_id)
     return {"status": "deleted"}
 
 
@@ -148,8 +171,26 @@ async def get_conversation_messages(request: Request, conversation_id: str, user
 
 
 @router.get("/api/conversations/{conversation_id}/files")
-async def list_conversation_files(request: Request, conversation_id: str, user: dict = Depends(require_auth)):
-    """List files in a conversation's virtual filesystem."""
+async def list_conversation_files(
+    request: Request,
+    conversation_id: str,
+    scope: str = "session",
+    user: dict = Depends(require_auth),
+):
+    """List files relevant to a conversation.
+
+    Two scopes:
+      - ``scope=session`` (default): files tracked in the conversation's
+        accumulated state — every file the agent wrote in this thread,
+        plus any new outputs from past tool runs. Works without an active
+        sandbox; rendered from the LangGraph checkpoint.
+      - ``scope=workspace``: the live contents of /workspace on the
+        sandbox volume. Lazy-creates the sandbox if none is running.
+        Use this view to see everything currently on the volume,
+        including files this thread didn't track in state.
+
+    Read-only viewers (shared link without ownership) can use both scopes.
+    """
     db = get_db(request)
     user_id = get_user_id(request)
     mcp_tools = get_mcp_tools(request)
@@ -158,12 +199,21 @@ async def list_conversation_files(request: Request, conversation_id: str, user: 
 
     conversation = await db.get_conversation(conversation_id, user_id)
     if not conversation:
-        # Allow read-only access to other users' conversations
         conversation = await db.get_conversation_by_id(conversation_id)
         if not conversation:
             raise HTTPException(status_code=404, detail="Conversation not found")
 
     owner_id = conversation.get("user_id", user_id)
+
+    if scope == "workspace":
+        # Live filesystem listing — triggers sandbox creation if needed.
+        try:
+            return await list_thread_files(conversation_id)
+        except Exception as e:
+            logger.warning("Failed to list workspace files for %s", conversation_id, exc_info=True)
+            raise HTTPException(status_code=502, detail=f"Failed to list workspace files: {e}") from e
+
+    # Default: session-scope listing from state metadata.
     user_mcp, mcp_names = await _get_mcp_tools_for_owner(request, owner_id)
     owner_skills = await _get_skill_tools_for_owner(request, owner_id)
     graph = await get_agent_graph(
@@ -181,22 +231,24 @@ async def list_conversation_files(request: Request, conversation_id: str, user: 
 
     file_list = []
     for path, file_data in files.items():
-        content_lines = file_data.get("content", [])
-        encoding = file_data.get("encoding")
-        if encoding == "base64":
-            # Base64 files store raw size differently
-            b64_str = content_lines[0] if content_lines else ""
-            size = len(b64_str) * 3 // 4  # Approximate decoded size
-        else:
-            content_str = "\n".join(content_lines)
-            size = len(content_str.encode("utf-8"))
+        # Schema after refactor: {size, modified_at, source, ...} — no content.
+        # Tolerate legacy entries (which had {content: [...], ...}) by computing
+        # size from content_lines if size key is absent.
+        size = file_data.get("size")
+        if size is None:
+            content_lines = file_data.get("content", []) or []
+            encoding = file_data.get("encoding")
+            if encoding == "base64":
+                b64_str = content_lines[0] if content_lines else ""
+                size = len(b64_str) * 3 // 4
+            else:
+                size = len("\n".join(content_lines).encode("utf-8"))
         file_list.append(
             {
                 "path": path,
                 "size": size,
                 "source": file_data.get("source", "agent"),
                 "modified_at": file_data.get("modified_at", ""),
-                "encoding": encoding,
             }
         )
     return file_list
@@ -206,7 +258,16 @@ async def list_conversation_files(request: Request, conversation_id: str, user: 
 async def get_conversation_file(
     request: Request, conversation_id: str, file_path: str, user: dict = Depends(require_auth)
 ):
-    """Get a file's contents from a conversation's virtual filesystem."""
+    """Get a file's contents from the conversation's workspace.
+
+    Fetched live from the sandbox filesystem. Lazy-creates the sandbox if
+    none exists; the cold-start latency is on the click that triggered
+    this fetch. Read-only viewers can read any path the workspace exposes.
+
+    Returns ``{path, content, encoding, modified_at}``. Binary content is
+    returned base64-encoded (encoding="base64"); text is utf-8 decoded
+    with ``errors='replace'`` (encoding="utf-8").
+    """
     db = get_db(request)
     user_id = get_user_id(request)
     mcp_tools = get_mcp_tools(request)
@@ -215,40 +276,107 @@ async def get_conversation_file(
 
     conversation = await db.get_conversation(conversation_id, user_id)
     if not conversation:
-        # Allow read-only access to other users' conversations
         conversation = await db.get_conversation_by_id(conversation_id)
         if not conversation:
             raise HTTPException(status_code=404, detail="Conversation not found")
 
-    owner_id = conversation.get("user_id", user_id)
-    user_mcp, mcp_names = await _get_mcp_tools_for_owner(request, owner_id)
-    owner_skills = await _get_skill_tools_for_owner(request, owner_id)
-    graph = await get_agent_graph(
-        mcp_tools,
-        checkpointer,
-        user_id=owner_id,
-        db=db,
-        vectorstore_manager=vectorstore_manager,
-        mcp_tools_by_server=user_mcp,
-        mcp_server_names=mcp_names,
-        skill_tools=owner_skills,
-    )
-    state = await graph.aget_state({"configurable": {"thread_id": conversation_id}})
-    files = state.values.get("files", {})
-
-    # Normalize path -- the stored keys start with /
     lookup_path = file_path if file_path.startswith("/") else "/" + file_path
-    file_data = files.get(lookup_path)
-    if not file_data:
-        raise HTTPException(status_code=404, detail="File not found")
 
-    content_lines = file_data.get("content", [])
-    encoding = file_data.get("encoding")
-    content_str = "\n".join(content_lines)
+    # If state has legacy content for this path (pre-volume migration),
+    # pass it along as a fallback so fetch_file_content can lazy-write it
+    # to the workspace volume on first read.
+    owner_id = conversation.get("user_id", user_id)
+    legacy_fallback: bytes | None = None
+    try:
+        user_mcp, mcp_names = await _get_mcp_tools_for_owner(request, owner_id)
+        owner_skills = await _get_skill_tools_for_owner(request, owner_id)
+        graph = await get_agent_graph(
+            mcp_tools,
+            checkpointer,
+            user_id=owner_id,
+            db=db,
+            vectorstore_manager=vectorstore_manager,
+            mcp_tools_by_server=user_mcp,
+            mcp_server_names=mcp_names,
+            skill_tools=owner_skills,
+        )
+        state = await graph.aget_state({"configurable": {"thread_id": conversation_id}})
+        files = state.values.get("files", {})
+        entry = files.get(lookup_path)
+        if entry and "content" in entry:
+            content_lines = entry.get("content", []) or []
+            encoding = entry.get("encoding")
+            if encoding == "base64":
+                b64_str = content_lines[0] if content_lines else ""
+                try:
+                    legacy_fallback = base64.b64decode(b64_str)
+                except Exception:
+                    legacy_fallback = None
+            else:
+                legacy_fallback = "\n".join(content_lines).encode("utf-8")
+    except Exception:
+        # Migration is best-effort; if we can't read state, just try the
+        # live filesystem and let it 404 if missing.
+        logger.warning("Legacy fallback lookup failed for %s/%s", conversation_id, lookup_path, exc_info=True)
 
-    return {
-        "path": lookup_path,
-        "content": content_str,
-        "encoding": encoding,
-        "modified_at": file_data.get("modified_at", ""),
-    }
+    try:
+        content_bytes, modified_at = await fetch_file_content(conversation_id, lookup_path, legacy_fallback)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail="File not found") from e
+    except Exception as e:
+        logger.warning("Failed to fetch file %s for conversation %s", lookup_path, conversation_id, exc_info=True)
+        raise HTTPException(status_code=502, detail=f"Failed to fetch file: {e}") from e
+
+    # Heuristic: try utf-8 first (errors=strict to detect binary), fall back
+    # to base64. This avoids encoding plain text files as base64.
+    try:
+        text = content_bytes.decode("utf-8")
+        return {
+            "path": lookup_path,
+            "content": text,
+            "encoding": "utf-8",
+            "modified_at": modified_at,
+        }
+    except UnicodeDecodeError:
+        return {
+            "path": lookup_path,
+            "content": base64.b64encode(content_bytes).decode("ascii"),
+            "encoding": "base64",
+            "modified_at": modified_at,
+        }
+
+
+@router.get("/api/conversations/{conversation_id}/files/{file_path:path}/raw")
+async def download_conversation_file(
+    request: Request, conversation_id: str, file_path: str, user: dict = Depends(require_auth)
+):
+    """Download a file's raw bytes for the conversation.
+
+    Same auth as the JSON-content endpoint (read-only access via shared
+    link is allowed). Streams binary content with the appropriate filename.
+    """
+    db = get_db(request)
+    user_id = get_user_id(request)
+
+    conversation = await db.get_conversation(conversation_id, user_id)
+    if not conversation:
+        conversation = await db.get_conversation_by_id(conversation_id)
+        if not conversation:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+
+    lookup_path = file_path if file_path.startswith("/") else "/" + file_path
+
+    try:
+        content_bytes, _ = await fetch_file_content(conversation_id, lookup_path)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail="File not found") from e
+    except Exception as e:
+        logger.warning("Failed to fetch file %s for conversation %s", lookup_path, conversation_id, exc_info=True)
+        raise HTTPException(status_code=502, detail=f"Failed to fetch file: {e}") from e
+
+    filename = lookup_path.rsplit("/", 1)[-1] or "file"
+    return Response(
+        content=content_bytes,
+        media_type="application/octet-stream",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/src/rhiza_agents/routes/conversations.py
+++ b/src/rhiza_agents/routes/conversations.py
@@ -11,7 +11,7 @@ from fastapi.responses import Response
 
 from ..agents.registry import get_default_configs, merge_configs
 from ..agents.supervisor import get_agent_graph
-from ..agents.tools.files import fetch_file_content, list_thread_files
+from ..agents.tools.files import FileTooLargeError, fetch_file_content, list_thread_files
 from ..agents.tools.sandbox import cleanup_sandbox, cleanup_thread_workspace_async
 from ..db.models import AgentConfig
 from ..deps import (
@@ -366,6 +366,8 @@ async def get_conversation_file(
         content_bytes, modified_at = await fetch_file_content(conversation_id, lookup_path, legacy_fallback)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail="File not found") from e
+    except FileTooLargeError as e:
+        raise HTTPException(status_code=413, detail=f"File too large to view ({e.size} bytes)") from e
     except Exception as e:
         logger.warning("Failed to fetch file %s for conversation %s", lookup_path, conversation_id, exc_info=True)
         raise HTTPException(status_code=502, detail=f"Failed to fetch file: {e}") from e
@@ -413,6 +415,8 @@ async def download_conversation_file(
         content_bytes, _ = await fetch_file_content(conversation_id, lookup_path)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail="File not found") from e
+    except FileTooLargeError as e:
+        raise HTTPException(status_code=413, detail=f"File too large to download ({e.size} bytes)") from e
     except Exception as e:
         logger.warning("Failed to fetch file %s for conversation %s", lookup_path, conversation_id, exc_info=True)
         raise HTTPException(status_code=502, detail=f"Failed to fetch file: {e}") from e

--- a/src/rhiza_agents/routes/conversations.py
+++ b/src/rhiza_agents/routes/conversations.py
@@ -308,7 +308,13 @@ async def get_conversation_file(
     checkpointer = get_checkpointer(request)
     vectorstore_manager = get_vectorstore_manager(request)
 
+    # get_conversation(…, user_id) returns truthy only when the requester
+    # owns the conversation; get_conversation_by_id is the read-only
+    # viewer fallback (shared-link access). Only the owner may trigger the
+    # lazy migration write to their own volume — a non-owner viewer gets
+    # read-only behavior (404 if the file isn't materialized yet).
     conversation = await db.get_conversation(conversation_id, user_id)
+    is_owner = conversation is not None
     if not conversation:
         conversation = await db.get_conversation_by_id(conversation_id)
         if not conversation:
@@ -318,40 +324,43 @@ async def get_conversation_file(
 
     # If state has legacy content for this path (pre-volume migration),
     # pass it along as a fallback so fetch_file_content can lazy-write it
-    # to the workspace volume on first read.
+    # to the workspace volume on first read. Owner-only: a non-owner must
+    # not cause a write to the owner's volume, so we leave legacy_fallback
+    # as None for viewers.
     owner_id = conversation.get("user_id", user_id)
     legacy_fallback: bytes | None = None
-    try:
-        user_mcp, mcp_names = await _get_mcp_tools_for_owner(request, owner_id)
-        owner_skills = await _get_skill_tools_for_owner(request, owner_id)
-        graph = await get_agent_graph(
-            mcp_tools,
-            checkpointer,
-            user_id=owner_id,
-            db=db,
-            vectorstore_manager=vectorstore_manager,
-            mcp_tools_by_server=user_mcp,
-            mcp_server_names=mcp_names,
-            skill_tools=owner_skills,
-        )
-        state = await graph.aget_state({"configurable": {"thread_id": conversation_id}})
-        files = state.values.get("files", {})
-        entry = files.get(lookup_path)
-        if entry and "content" in entry:
-            content_lines = entry.get("content", []) or []
-            encoding = entry.get("encoding")
-            if encoding == "base64":
-                b64_str = content_lines[0] if content_lines else ""
-                try:
-                    legacy_fallback = base64.b64decode(b64_str)
-                except Exception:
-                    legacy_fallback = None
-            else:
-                legacy_fallback = "\n".join(content_lines).encode("utf-8")
-    except Exception:
-        # Migration is best-effort; if we can't read state, just try the
-        # live filesystem and let it 404 if missing.
-        logger.warning("Legacy fallback lookup failed for %s/%s", conversation_id, lookup_path, exc_info=True)
+    if is_owner:
+        try:
+            user_mcp, mcp_names = await _get_mcp_tools_for_owner(request, owner_id)
+            owner_skills = await _get_skill_tools_for_owner(request, owner_id)
+            graph = await get_agent_graph(
+                mcp_tools,
+                checkpointer,
+                user_id=owner_id,
+                db=db,
+                vectorstore_manager=vectorstore_manager,
+                mcp_tools_by_server=user_mcp,
+                mcp_server_names=mcp_names,
+                skill_tools=owner_skills,
+            )
+            state = await graph.aget_state({"configurable": {"thread_id": conversation_id}})
+            files = state.values.get("files", {})
+            entry = files.get(lookup_path)
+            if entry and "content" in entry:
+                content_lines = entry.get("content", []) or []
+                encoding = entry.get("encoding")
+                if encoding == "base64":
+                    b64_str = content_lines[0] if content_lines else ""
+                    try:
+                        legacy_fallback = base64.b64decode(b64_str)
+                    except Exception:
+                        legacy_fallback = None
+                else:
+                    legacy_fallback = "\n".join(content_lines).encode("utf-8")
+        except Exception:
+            # Migration is best-effort; if we can't read state, just try the
+            # live filesystem and let it 404 if missing.
+            logger.warning("Legacy fallback lookup failed for %s/%s", conversation_id, lookup_path, exc_info=True)
 
     try:
         content_bytes, modified_at = await fetch_file_content(conversation_id, lookup_path, legacy_fallback)

--- a/tests/test_cleanup_thread_workspace.py
+++ b/tests/test_cleanup_thread_workspace.py
@@ -1,0 +1,137 @@
+"""Tests for cleanup_thread_workspace's two execution paths.
+
+The helper either reuses the active per-thread sandbox (when one is
+alive in _sandboxes) or spins up a temp sandbox just to do the rm.
+The reused-sandbox path saves the ~5–15s sandbox-create cost on every
+conversation delete where the sandbox was still alive when the delete
+came in. Tests verify the dispatch.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from rhiza_agents.agents.tools import sandbox as sbx
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_state(monkeypatch):
+    """Each test runs against an empty _sandboxes dict and a known volume
+    env var so the helper takes the path under test.
+    """
+    monkeypatch.setattr(sbx, "_sandboxes", {})
+    monkeypatch.setenv("DAYTONA_HOMES_VOLUME", "homes")
+    monkeypatch.delenv("DAYTONA_HOMES_MOUNT_PATH", raising=False)
+
+
+class _RecordingSandbox:
+    """Sandbox stub that records process.exec calls and the configured
+    response (default: success)."""
+
+    def __init__(self, exit_code: int = 0, result: str = ""):
+        self.exec_calls: list[str] = []
+        self._exit_code = exit_code
+        self._result = result
+
+        class _P:
+            def exec(p_self, cmd, **_kwargs):  # noqa: N805
+                self.exec_calls.append(cmd)
+                return SimpleNamespace(exit_code=self._exit_code, result=self._result)
+
+        self.process = _P()
+
+
+def test_uses_active_sandbox_when_alive():
+    """Path 1: the per-thread sandbox is in _sandboxes; cleanup runs the
+    rm through it and never creates a temp sandbox."""
+    active = _RecordingSandbox()
+    sbx._sandboxes["thread-x"] = active
+
+    with mock.patch.object(sbx, "_get_daytona") as mock_daytona:
+        sbx.cleanup_thread_workspace("thread-x")
+
+        # Temp-sandbox path was never invoked.
+        mock_daytona.assert_not_called()
+
+    # The rm command landed on the active sandbox.
+    assert len(active.exec_calls) == 1
+    assert "find /workspace -mindepth 1 -delete" in active.exec_calls[0]
+
+
+def test_falls_back_to_temp_sandbox_when_none_alive():
+    """Path 2: no per-thread sandbox in _sandboxes; cleanup creates a
+    temp sandbox, runs the rm, and deletes the temp sandbox."""
+    temp = _RecordingSandbox()
+
+    fake_volume = SimpleNamespace(id="vol-id")
+    fake_daytona = mock.MagicMock()
+    fake_daytona.volume.get.return_value = fake_volume
+    fake_daytona.create.return_value = temp
+
+    with mock.patch.object(sbx, "_get_daytona", return_value=fake_daytona):
+        sbx.cleanup_thread_workspace("thread-y")
+
+    # Temp sandbox was created and deleted.
+    fake_daytona.create.assert_called_once()
+    fake_daytona.delete.assert_called_once_with(temp)
+    # The rm ran on the temp sandbox.
+    assert len(temp.exec_calls) == 1
+    assert "find /workspace -mindepth 1 -delete" in temp.exec_calls[0]
+
+
+def test_falls_back_to_temp_sandbox_when_active_path_raises():
+    """Path 1 is attempted, raises, helper falls through to path 2.
+    Verifies an unhealthy active sandbox doesn't strand the cleanup."""
+    broken_active = _RecordingSandbox()
+
+    def _broken_exec(cmd, **_kwargs):
+        broken_active.exec_calls.append(cmd)
+        raise RuntimeError("sandbox unreachable")
+
+    broken_active.process.exec = _broken_exec
+    sbx._sandboxes["thread-z"] = broken_active
+
+    temp = _RecordingSandbox()
+    fake_volume = SimpleNamespace(id="vol-id")
+    fake_daytona = mock.MagicMock()
+    fake_daytona.volume.get.return_value = fake_volume
+    fake_daytona.create.return_value = temp
+
+    with mock.patch.object(sbx, "_get_daytona", return_value=fake_daytona):
+        sbx.cleanup_thread_workspace("thread-z")
+
+    # Active path tried + failed.
+    assert len(broken_active.exec_calls) == 1
+    # Temp path ran the rm.
+    fake_daytona.create.assert_called_once()
+    fake_daytona.delete.assert_called_once_with(temp)
+    assert len(temp.exec_calls) == 1
+
+
+def test_no_op_when_homes_volume_unset(monkeypatch):
+    """If DAYTONA_HOMES_VOLUME is empty there's no per-conversation
+    workspace to clean — return immediately, don't touch any sandbox."""
+    monkeypatch.setenv("DAYTONA_HOMES_VOLUME", "")
+    active = _RecordingSandbox()
+    sbx._sandboxes["thread-q"] = active
+
+    with mock.patch.object(sbx, "_get_daytona") as mock_daytona:
+        sbx.cleanup_thread_workspace("thread-q")
+
+    # Nothing happened: no exec on the active sandbox, no Daytona client touch.
+    assert active.exec_calls == []
+    mock_daytona.assert_not_called()
+
+
+def test_uses_custom_homes_mount_path(monkeypatch):
+    """If DAYTONA_HOMES_MOUNT_PATH overrides /workspace, the rm targets
+    that path — the helper does not hardcode SANDBOX_WORKSPACE."""
+    monkeypatch.setenv("DAYTONA_HOMES_MOUNT_PATH", "/persist")
+    active = _RecordingSandbox()
+    sbx._sandboxes["thread-w"] = active
+
+    with mock.patch.object(sbx, "_get_daytona"):
+        sbx.cleanup_thread_workspace("thread-w")
+
+    assert "find /persist -mindepth 1 -delete" in active.exec_calls[0]

--- a/tests/test_cleanup_thread_workspace.py
+++ b/tests/test_cleanup_thread_workspace.py
@@ -135,3 +135,33 @@ def test_uses_custom_homes_mount_path(monkeypatch):
         sbx.cleanup_thread_workspace("thread-w")
 
     assert "find /persist -mindepth 1 -delete" in active.exec_calls[0]
+
+
+@pytest.mark.parametrize("bad_path", ["/", "/etc", "/var", "/home", "/root", "/usr", "/.."])
+def test_refuses_unsafe_homes_mount_path(monkeypatch, bad_path):
+    """A misconfigured homes mount path that resolves to a system tree
+    must not run the recursive delete — no exec, no temp sandbox."""
+    monkeypatch.setenv("DAYTONA_HOMES_MOUNT_PATH", bad_path)
+    active = _RecordingSandbox()
+    sbx._sandboxes["thread-bad"] = active
+
+    with mock.patch.object(sbx, "_get_daytona") as mock_daytona:
+        sbx.cleanup_thread_workspace("thread-bad")
+
+    # Guard fired before any filesystem-touching command ran.
+    assert active.exec_calls == []
+    mock_daytona.assert_not_called()
+
+
+def test_is_safe_cleanup_path_guard():
+    """Direct check of the guard predicate: dedicated mounts allowed,
+    system trees and empty/relative paths refused."""
+    assert sbx._is_safe_cleanup_path("/workspace") is True
+    assert sbx._is_safe_cleanup_path("/persist") is True
+    assert sbx._is_safe_cleanup_path("/data/homes") is True
+    assert sbx._is_safe_cleanup_path("/") is False
+    assert sbx._is_safe_cleanup_path("") is False
+    assert sbx._is_safe_cleanup_path("relative/path") is False
+    assert sbx._is_safe_cleanup_path("/etc") is False
+    # Normalization collapses traversal back to "/".
+    assert sbx._is_safe_cleanup_path("/..") is False

--- a/tests/test_cleanup_thread_workspace.py
+++ b/tests/test_cleanup_thread_workspace.py
@@ -137,10 +137,28 @@ def test_uses_custom_homes_mount_path(monkeypatch):
     assert "find /persist -mindepth 1 -delete" in active.exec_calls[0]
 
 
-@pytest.mark.parametrize("bad_path", ["/", "/etc", "/var", "/home", "/root", "/usr", "/.."])
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "/",
+        "/etc",
+        "/var",
+        "/home",
+        "/root",
+        "/usr",
+        "/..",
+        # Nested system paths: a child of a forbidden root is just as
+        # dangerous to recursively empty as the root itself.
+        "/etc/cron.d",
+        "/var/lib/postgresql",
+        "/usr/local/bin",
+        "/home/someuser",
+    ],
+)
 def test_refuses_unsafe_homes_mount_path(monkeypatch, bad_path):
     """A misconfigured homes mount path that resolves to a system tree
-    must not run the recursive delete — no exec, no temp sandbox."""
+    (or a path nested under one) must not run the recursive delete — no
+    exec, no temp sandbox."""
     monkeypatch.setenv("DAYTONA_HOMES_MOUNT_PATH", bad_path)
     active = _RecordingSandbox()
     sbx._sandboxes["thread-bad"] = active
@@ -151,6 +169,22 @@ def test_refuses_unsafe_homes_mount_path(monkeypatch, bad_path):
     # Guard fired before any filesystem-touching command ran.
     assert active.exec_calls == []
     mock_daytona.assert_not_called()
+
+
+def test_is_safe_cleanup_path_rejects_nested_system_paths():
+    """Prefix-based rejection: a path under any forbidden root is unsafe,
+    while a legitimate deep mount outside every forbidden root is allowed."""
+    # Nested under a forbidden system root → refused.
+    assert sbx._is_safe_cleanup_path("/etc/cron.d") is False
+    assert sbx._is_safe_cleanup_path("/var/lib/postgresql") is False
+    assert sbx._is_safe_cleanup_path("/usr/local/lib") is False
+    assert sbx._is_safe_cleanup_path("/home/alice/data") is False
+    # A deep mount path outside every forbidden root → allowed.
+    assert sbx._is_safe_cleanup_path("/mnt/homes") is True
+    assert sbx._is_safe_cleanup_path("/mnt/homes/thread-123") is True
+    # A prefix that merely starts with a forbidden root's name but is not
+    # actually nested under it (no trailing slash boundary) is allowed.
+    assert sbx._is_safe_cleanup_path("/etcdata") is True
 
 
 def test_is_safe_cleanup_path_guard():

--- a/tests/test_content_disposition.py
+++ b/tests/test_content_disposition.py
@@ -1,0 +1,95 @@
+"""Tests for the Content-Disposition header builder used by the file
+download endpoint.
+
+The helper has to be safe for filenames sourced from agent or skill
+output. The biggest concern is header injection via CR/LF — a filename
+containing ``\\r\\n`` could otherwise add a new header to the response.
+"""
+
+from rhiza_agents.routes.conversations import _content_disposition_attachment
+
+
+def test_simple_ascii_filename():
+    h = _content_disposition_attachment("hello.txt")
+    assert h == "attachment; filename=\"hello.txt\"; filename*=UTF-8''hello.txt"
+
+
+def test_double_quote_in_filename_is_escaped_in_ascii_part():
+    h = _content_disposition_attachment('say "hi".txt')
+    # The ASCII filename="..." form must escape the embedded quote so
+    # the value cannot end early.
+    assert 'filename="say \\"hi\\".txt"' in h
+    # The pct-encoded form encodes the quote.
+    assert "filename*=UTF-8''say%20%22hi%22.txt" in h
+
+
+def test_backslash_in_filename_is_escaped():
+    h = _content_disposition_attachment("path\\to\\thing.txt")
+    assert 'filename="path\\\\to\\\\thing.txt"' in h
+
+
+def test_cr_lf_stripped_to_prevent_header_injection():
+    # The injection vector: a filename containing CRLF could break
+    # out of the Content-Disposition value into a new header line.
+    h = _content_disposition_attachment("foo\r\nX-Injected: bar.txt")
+    # Neither raw CR nor LF may appear in the final header value.
+    assert "\r" not in h
+    assert "\n" not in h
+    # The injected token survives as inert bytes within the filename;
+    # it just can't form a new header.
+    assert "X-Injected:" in h
+
+
+def test_control_characters_stripped():
+    # NUL and other ASCII control chars in 0x00-0x1F + 0x7F range.
+    h = _content_disposition_attachment("a\x00b\x07c\x1fd\x7fe.txt")
+    # Result should contain only the printable letters.
+    assert 'filename="abcde.txt"' in h
+
+
+def test_unicode_filename_uses_pct_encoded_form():
+    h = _content_disposition_attachment("café.csv")
+    # Non-ASCII becomes ? in the ascii fallback.
+    assert 'filename="caf?.csv"' in h
+    # And percent-encoded UTF-8 in the modern form.
+    assert "filename*=UTF-8''caf%C3%A9.csv" in h
+
+
+def test_empty_filename_falls_back_to_default():
+    h = _content_disposition_attachment("")
+    assert 'filename="file"' in h
+    assert "filename*=UTF-8''file" in h
+
+
+def test_only_control_chars_falls_back_to_default():
+    h = _content_disposition_attachment("\r\n\x00\x07")
+    assert 'filename="file"' in h
+
+
+def test_starts_with_attachment_disposition():
+    # Always sets attachment disposition (download), never inline.
+    assert _content_disposition_attachment("x.txt").startswith("attachment;")
+
+
+def test_no_unescaped_quote_can_terminate_filename_value():
+    """Header parsers locate the end of the filename="..." value at the
+    first unescaped double quote. Ensure escaping is tight enough that a
+    pathological input can't terminate early.
+    """
+    pathological = 'a"; attachment; filename="b'
+    h = _content_disposition_attachment(pathological)
+    # Find the filename= token and verify the next " is escaped (i.e.
+    # preceded by a backslash) until the actual closing quote.
+    start = h.index('filename="') + len('filename="')
+    # Walk the value byte by byte; the only unescaped " must be at the
+    # very end of the filename token before the trailing semicolon.
+    i = start
+    while i < len(h):
+        if h[i] == '"' and h[i - 1] != "\\":
+            break
+        i += 1
+    # After that closing quote we expect "; filename*=" — the modern
+    # form follows. If pathological input had broken out, we'd find a
+    # bare "; attachment;" sequence inside the ASCII form.
+    rest = h[i + 1 :]
+    assert rest.startswith("; filename*="), f"unexpected suffix: {rest!r}"

--- a/tests/test_conversation_file_ownership.py
+++ b/tests/test_conversation_file_ownership.py
@@ -1,0 +1,114 @@
+"""Tests for ownership-gated legacy migration in get_conversation_file.
+
+The file-content endpoint serves both the conversation owner and
+read-only viewers (shared-link access). Only the owner may trigger the
+lazy migration write that materializes pre-volume state-stored content
+onto the owner's workspace volume. A non-owner viewer requesting a file
+that isn't on the volume yet must get a read-only 404 with no write to
+the owner's volume — i.e. fetch_file_content must be called with
+legacy_fallback=None.
+
+Ownership is decided by db.get_conversation(conversation_id, user_id):
+truthy == requester is the owner; the get_conversation_by_id fallback ==
+read-only viewer.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from rhiza_agents.routes import conversations as conv
+
+
+class _FakeRequest:
+    """Minimal Request stand-in exposing app.state and session.
+
+    The route handler reads its dependencies (db, checkpointer,
+    mcp_tools, vectorstore_manager, user_id) off request.app.state and
+    request.session.
+    """
+
+    def __init__(self, db, user_sub):
+        self.app = SimpleNamespace(
+            state=SimpleNamespace(
+                db=db,
+                checkpointer=object(),
+                mcp_tools=[],
+                mcp_tools_by_server={},
+                vectorstore_manager=object(),
+                config=object(),
+            )
+        )
+        self.session = {"user": {"sub": user_sub}}
+
+
+def _make_db(*, owner_lookup, by_id_lookup):
+    """Build an async-mocked db with the two ownership lookups stubbed."""
+    db = mock.MagicMock()
+    db.get_conversation = mock.AsyncMock(return_value=owner_lookup)
+    db.get_conversation_by_id = mock.AsyncMock(return_value=by_id_lookup)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_non_owner_gets_no_legacy_fallback(monkeypatch):
+    """A viewer (get_conversation returns None, get_conversation_by_id
+    returns the row) must not trigger a migration write: the handler
+    passes legacy_fallback=None and the missing file 404s."""
+    db = _make_db(owner_lookup=None, by_id_lookup={"user_id": "owner-1"})
+    request = _FakeRequest(db, user_sub="viewer-2")
+
+    captured = {}
+
+    async def _fake_fetch(thread_id, lookup_path, legacy_fallback=None):
+        captured["legacy_fallback"] = legacy_fallback
+        raise FileNotFoundError(lookup_path)
+
+    monkeypatch.setattr(conv, "fetch_file_content", _fake_fetch)
+    # Guard: the owner-only state lookup must not run for a viewer.
+    monkeypatch.setattr(
+        conv,
+        "_get_mcp_tools_for_owner",
+        mock.AsyncMock(side_effect=AssertionError("viewer must not read owner state")),
+    )
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await conv.get_conversation_file(request, "conv-1", "secret.txt", user={})
+
+    assert exc.value.status_code == 404
+    assert captured["legacy_fallback"] is None
+
+
+@pytest.mark.asyncio
+async def test_owner_gets_legacy_fallback_from_state(monkeypatch):
+    """The owner (get_conversation returns the row) gets the state's
+    stored content passed as legacy_fallback so fetch_file_content can
+    migrate it onto the volume."""
+    db = _make_db(owner_lookup={"user_id": "owner-1"}, by_id_lookup=None)
+    request = _FakeRequest(db, user_sub="owner-1")
+
+    # State carries legacy content for the requested path.
+    fake_state = SimpleNamespace(values={"files": {"/secret.txt": {"content": ["hello world"], "encoding": "utf-8"}}})
+    fake_graph = mock.MagicMock()
+    fake_graph.aget_state = mock.AsyncMock(return_value=fake_state)
+
+    monkeypatch.setattr(conv, "_get_mcp_tools_for_owner", mock.AsyncMock(return_value=({}, {})))
+    monkeypatch.setattr(conv, "_get_skill_tools_for_owner", mock.AsyncMock(return_value={}))
+    monkeypatch.setattr(conv, "get_agent_graph", mock.AsyncMock(return_value=fake_graph))
+
+    captured = {}
+
+    async def _fake_fetch(thread_id, lookup_path, legacy_fallback=None):
+        captured["legacy_fallback"] = legacy_fallback
+        return (b"hello world", "2026-01-01T00:00:00+00:00")
+
+    monkeypatch.setattr(conv, "fetch_file_content", _fake_fetch)
+
+    result = await conv.get_conversation_file(request, "conv-1", "secret.txt", user={})
+
+    assert captured["legacy_fallback"] == b"hello world"
+    assert result["content"] == "hello world"
+    assert result["encoding"] == "utf-8"

--- a/tests/test_fetch_file_size_cap.py
+++ b/tests/test_fetch_file_size_cap.py
@@ -77,6 +77,28 @@ async def test_at_limit_file_is_read(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_grown_file_rejected_after_read(monkeypatch):
+    # TOCTOU: stat reports a size under the cap, but the file grew past
+    # the cap by the time read_workspace_file pulls it. The actual-bytes
+    # check after the read must reject it.
+    sandbox = _StatSandbox(size=MAX_FETCH_FILE_BYTES - 10)
+
+    monkeypatch.setattr(
+        files_mod,
+        "read_workspace_file",
+        lambda _s, _p: b"x" * (MAX_FETCH_FILE_BYTES + 1),
+    )
+    monkeypatch.setattr(
+        "rhiza_agents.agents.tools.sandbox._get_or_create_sandbox",
+        lambda _tid: sandbox,
+    )
+
+    with pytest.raises(FileTooLargeError) as exc:
+        await fetch_file_content("thread-1", "/grew.bin")
+    assert exc.value.size == MAX_FETCH_FILE_BYTES + 1
+
+
+@pytest.mark.asyncio
 async def test_oversized_legacy_fallback_rejected_before_write(monkeypatch):
     # File absent on the volume (stat fails), and the legacy fallback
     # itself is over the cap — must reject without writing it.

--- a/tests/test_fetch_file_size_cap.py
+++ b/tests/test_fetch_file_size_cap.py
@@ -20,7 +20,13 @@ from rhiza_agents.agents.tools.files import (
 
 
 class _StatSandbox:
-    """Sandbox stub whose process.exec answers the stat with a fixed size."""
+    """Sandbox stub whose process.exec answers the stat with a fixed size.
+
+    The realpath-containment guard (``_assert_realpath_contained``) runs a
+    ``realpath -m`` before the stat; this stub answers that with a
+    contained /workspace path so the guard passes and the size-cap logic
+    is reached.
+    """
 
     def __init__(self, size: int, mtime: int = 1700000000):
         self._size = size
@@ -29,7 +35,9 @@ class _StatSandbox:
 
         class _P:
             def exec(p_self, cmd, **_kwargs):  # noqa: N805
-                # Only the stat command is exercised in these tests.
+                if cmd.startswith("realpath"):
+                    return SimpleNamespace(exit_code=0, result="/workspace/x")
+                # The stat command for the size cap under test.
                 return SimpleNamespace(exit_code=0, result=f"{self._size}|{self._mtime}")
 
         self.process = _P()
@@ -76,6 +84,10 @@ async def test_oversized_legacy_fallback_rejected_before_write(monkeypatch):
         def __init__(self):
             class _P:
                 def exec(p_self, cmd, **_kwargs):  # noqa: N805
+                    # realpath -m resolves the (contained) path so the
+                    # guard passes; the stat then reports the file missing.
+                    if cmd.startswith("realpath"):
+                        return SimpleNamespace(exit_code=0, result="/workspace/big.bin")
                     return SimpleNamespace(exit_code=1, result="")
 
             self.process = _P()

--- a/tests/test_fetch_file_size_cap.py
+++ b/tests/test_fetch_file_size_cap.py
@@ -1,0 +1,138 @@
+"""Tests for the file-size cap in fetch_file_content.
+
+The file endpoint reads the whole file into memory; without a cap a
+multi-GB artifact on /data would OOM the server. fetch_file_content
+stats the file first and rejects anything above MAX_FETCH_FILE_BYTES
+with FileTooLargeError BEFORE read_workspace_file pulls the content in.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from rhiza_agents.agents.tools import files as files_mod
+from rhiza_agents.agents.tools.files import (
+    MAX_FETCH_FILE_BYTES,
+    FileTooLargeError,
+    fetch_file_content,
+)
+
+
+class _StatSandbox:
+    """Sandbox stub whose process.exec answers the stat with a fixed size."""
+
+    def __init__(self, size: int, mtime: int = 1700000000):
+        self._size = size
+        self._mtime = mtime
+        self.read_called = False
+
+        class _P:
+            def exec(p_self, cmd, **_kwargs):  # noqa: N805
+                # Only the stat command is exercised in these tests.
+                return SimpleNamespace(exit_code=0, result=f"{self._size}|{self._mtime}")
+
+        self.process = _P()
+
+
+@pytest.mark.asyncio
+async def test_oversized_file_rejected_before_read(monkeypatch):
+    sandbox = _StatSandbox(size=MAX_FETCH_FILE_BYTES + 1)
+
+    def _fake_read(_sandbox, _abs_path):
+        # If this fires the cap failed to short-circuit the read.
+        raise AssertionError("read_workspace_file must not run for oversized file")
+
+    monkeypatch.setattr(files_mod, "read_workspace_file", _fake_read)
+    monkeypatch.setattr(
+        "rhiza_agents.agents.tools.sandbox._get_or_create_sandbox",
+        lambda _tid: sandbox,
+    )
+
+    with pytest.raises(FileTooLargeError) as exc:
+        await fetch_file_content("thread-1", "/big.bin")
+    assert exc.value.size == MAX_FETCH_FILE_BYTES + 1
+
+
+@pytest.mark.asyncio
+async def test_at_limit_file_is_read(monkeypatch):
+    sandbox = _StatSandbox(size=MAX_FETCH_FILE_BYTES)
+
+    monkeypatch.setattr(files_mod, "read_workspace_file", lambda _s, _p: b"x" * 10)
+    monkeypatch.setattr(
+        "rhiza_agents.agents.tools.sandbox._get_or_create_sandbox",
+        lambda _tid: sandbox,
+    )
+
+    content, _modified = await fetch_file_content("thread-1", "/atlimit.bin")
+    assert content == b"x" * 10
+
+
+@pytest.mark.asyncio
+async def test_oversized_legacy_fallback_rejected_before_write(monkeypatch):
+    # File absent on the volume (stat fails), and the legacy fallback
+    # itself is over the cap — must reject without writing it.
+    class _MissingSandbox:
+        def __init__(self):
+            class _P:
+                def exec(p_self, cmd, **_kwargs):  # noqa: N805
+                    return SimpleNamespace(exit_code=1, result="")
+
+            self.process = _P()
+
+    sandbox = _MissingSandbox()
+
+    def _fake_write(*_args, **_kwargs):
+        raise AssertionError("write_workspace_file must not run for oversized fallback")
+
+    monkeypatch.setattr(
+        "rhiza_agents.agents.tools.sandbox._get_or_create_sandbox",
+        lambda _tid: sandbox,
+    )
+    monkeypatch.setattr(
+        "rhiza_agents.agents.tools.sandbox.write_workspace_file",
+        _fake_write,
+    )
+
+    oversized = b"x" * (MAX_FETCH_FILE_BYTES + 1)
+    with pytest.raises(FileTooLargeError):
+        await fetch_file_content("thread-1", "/big.bin", legacy_fallback=oversized)
+
+
+@pytest.mark.asyncio
+async def test_route_maps_file_too_large_to_413(monkeypatch):
+    from fastapi import HTTPException
+
+    from rhiza_agents.routes import conversations as conv
+
+    db = mock.MagicMock()
+    db.get_conversation = mock.AsyncMock(return_value={"user_id": "owner-1"})
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                db=db,
+                checkpointer=object(),
+                mcp_tools=[],
+                mcp_tools_by_server={},
+                vectorstore_manager=object(),
+                config=object(),
+            )
+        ),
+        session={"user": {"sub": "owner-1"}},
+    )
+
+    monkeypatch.setattr(conv, "_get_mcp_tools_for_owner", mock.AsyncMock(return_value=({}, {})))
+    monkeypatch.setattr(conv, "_get_skill_tools_for_owner", mock.AsyncMock(return_value={}))
+    fake_graph = mock.MagicMock()
+    fake_graph.aget_state = mock.AsyncMock(return_value=SimpleNamespace(values={"files": {}}))
+    monkeypatch.setattr(conv, "get_agent_graph", mock.AsyncMock(return_value=fake_graph))
+
+    async def _fake_fetch(_tid, lookup_path, legacy_fallback=None):
+        raise FileTooLargeError(lookup_path, MAX_FETCH_FILE_BYTES + 1)
+
+    monkeypatch.setattr(conv, "fetch_file_content", _fake_fetch)
+
+    with pytest.raises(HTTPException) as exc:
+        await conv.get_conversation_file(request, "conv-1", "big.bin", user={})
+    assert exc.value.status_code == 413

--- a/tests/test_sandbox_helpers.py
+++ b/tests/test_sandbox_helpers.py
@@ -1,0 +1,258 @@
+"""Tests for the pure-ish helpers in tools/sandbox.py.
+
+Coverage:
+  - exec_as_daytona — that the su -l wrap actually wraps, that cwd is
+    cd'd into inside the wrap (su -l resets the shell so external cwd
+    won't propagate), and that env vars are exported inside the wrap.
+  - drain_inotify_journal — that the parser aggregates events per path,
+    picks the latest event as last_event, drops events outside the
+    watched volumes, filters /skills/, and skips paths that no longer
+    stat (deleted between event and drain).
+
+These run without a real Daytona sandbox by mocking the SDK-facing
+calls. The wrap correctness is the most security-relevant thing the
+unit tests can pin down — it's what enforces non-root execution.
+"""
+
+import base64
+import re
+from types import SimpleNamespace
+from unittest import mock
+
+from rhiza_agents.agents.tools.sandbox import (
+    drain_inotify_journal,
+    exec_as_daytona,
+)
+
+# ---------------------------------------------------------------------------
+# exec_as_daytona — the agent-execution privilege-drop wrapper
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSandbox:
+    """Sandbox stub that captures every process.exec call.
+
+    Returns ``exit_code=0`` with empty result by default. Tests inspect
+    ``self.exec_calls`` (the raw command strings) to verify wrapping
+    behavior.
+    """
+
+    def __init__(self):
+        self.exec_calls: list[tuple[str, dict]] = []
+
+        class _P:
+            def exec(p_self, cmd, **kwargs):  # noqa: N805 — match SDK
+                self.exec_calls.append((cmd, kwargs))
+                return SimpleNamespace(exit_code=0, result="")
+
+        self.process = _P()
+
+
+def _decode_inner(wrapped_cmd: str) -> str:
+    """Pull the base64-encoded inner shell command back out of a wrap.
+
+    The wrapper produces ``su -l daytona -c "echo <b64> | base64 -d | sh"``.
+    The base64 alphabet is shell-safe so ``shlex.quote`` returns it
+    unquoted; the regex below accepts that, plus the single-quoted
+    form in case shlex's behavior changes.
+    """
+    match = re.search(r"echo '?([A-Za-z0-9+/=]+)'? \| base64 -d \| sh", wrapped_cmd)
+    assert match, f"could not find base64 payload in wrapped command: {wrapped_cmd!r}"
+    return base64.b64decode(match.group(1)).decode("utf-8")
+
+
+def test_exec_as_daytona_wraps_with_su_l():
+    sandbox = _RecordingSandbox()
+    exec_as_daytona(sandbox, "ls /workspace")
+    cmd, _ = sandbox.exec_calls[0]
+    # The wrap is the only line of defense for non-root execution; verify
+    # it actually fires for every call.
+    assert cmd.startswith('su -l daytona -c "')
+    assert "base64 -d | sh" in cmd
+    inner = _decode_inner(cmd)
+    assert inner == "ls /workspace"
+
+
+def test_exec_as_daytona_cwd_injected_inside_wrap():
+    sandbox = _RecordingSandbox()
+    exec_as_daytona(sandbox, "pwd", cwd="/workspace")
+    inner = _decode_inner(sandbox.exec_calls[0][0])
+    # cwd has to be cd'd inside the wrapped shell because su -l starts
+    # a fresh login shell at $HOME — the outer process.exec cwd kwarg
+    # is not honored across the user switch.
+    assert "cd /workspace" in inner
+    assert "pwd" in inner
+    # Order matters: cd before the command.
+    assert inner.index("cd /workspace") < inner.index("pwd")
+
+
+def test_exec_as_daytona_env_exports_inside_wrap():
+    sandbox = _RecordingSandbox()
+    exec_as_daytona(sandbox, "echo $FOO", env={"FOO": "bar"})
+    inner = _decode_inner(sandbox.exec_calls[0][0])
+    # env has to be exported inside the wrap because su -l resets the
+    # environment to daytona's defaults.
+    assert "export FOO=bar" in inner
+    assert "echo $FOO" in inner
+
+
+def test_exec_as_daytona_quotes_env_value_with_special_chars():
+    sandbox = _RecordingSandbox()
+    exec_as_daytona(sandbox, "echo $X", env={"X": "a; rm -rf /"})
+    inner = _decode_inner(sandbox.exec_calls[0][0])
+    # The value must be shell-quoted so the embedded `; rm -rf /`
+    # doesn't get interpreted as a command separator.
+    assert "export X='a; rm -rf /'" in inner
+
+
+def test_exec_as_daytona_handles_command_with_quotes_and_dollars():
+    """Commands the agent supplies may contain shell metacharacters that
+    would otherwise be expanded twice (once by the outer su -c shell,
+    once by the inner sh). The base64 round-trip prevents that."""
+    sandbox = _RecordingSandbox()
+    tricky = """python3 -c 'import os; print("$HOME")'"""
+    exec_as_daytona(sandbox, tricky)
+    inner = _decode_inner(sandbox.exec_calls[0][0])
+    # Inner shell sees the original command literally — no expansion of
+    # $HOME by the outer su -c shell.
+    assert inner == tricky
+
+
+def test_exec_as_daytona_cwd_and_env_compose():
+    sandbox = _RecordingSandbox()
+    exec_as_daytona(sandbox, "do_thing", cwd="/data", env={"K": "v"})
+    inner = _decode_inner(sandbox.exec_calls[0][0])
+    # All three components appear, in the right order: env exports, cd,
+    # then the command.
+    assert inner.index("export K=v") < inner.index("cd /data")
+    assert inner.index("cd /data") < inner.index("do_thing")
+
+
+# ---------------------------------------------------------------------------
+# drain_inotify_journal — TSV parsing and path-source mapping
+# ---------------------------------------------------------------------------
+
+
+def _drain_with_responses(*responses: tuple[int, str], **kwargs):
+    """Invoke drain_inotify_journal with ``exec_as_daytona`` returning the
+    given (exit_code, result) responses in order.
+
+    First call is the drain (cat then truncate); second is the stat
+    batch over the surviving paths.
+    """
+    fake_responses = [SimpleNamespace(exit_code=ec, result=res) for ec, res in responses]
+    with mock.patch(
+        "rhiza_agents.agents.tools.sandbox.exec_as_daytona",
+        side_effect=fake_responses,
+    ) as patched:
+        result = drain_inotify_journal(sandbox=object(), **kwargs)
+    return result, patched
+
+
+def test_drain_empty_journal_returns_empty_dict():
+    result, _ = _drain_with_responses((0, ""))
+    assert result == {}
+
+
+def test_drain_aggregates_events_by_path_keeps_latest():
+    journal = (
+        "CREATE\t/workspace/foo.py\t1700000000\n"
+        "MODIFY\t/workspace/foo.py\t1700000005\n"
+        "CLOSE_WRITE\t/workspace/foo.py\t1700000010\n"
+    )
+    stat_out = "/workspace/foo.py|512|1700000010"
+    result, _ = _drain_with_responses((0, journal), (0, stat_out))
+    assert "/foo.py" in result
+    entry = result["/foo.py"]
+    # last_event is whichever event had the highest timestamp.
+    assert entry["last_event"] == "CLOSE_WRITE"
+    assert entry["size"] == 512
+    assert entry["source"] == "agent"  # default_source
+
+
+def test_drain_workspace_paths_use_default_source():
+    journal = "CREATE\t/workspace/a.py\t1700000000\n"
+    stat_out = "/workspace/a.py|10|1700000000"
+    result, _ = _drain_with_responses((0, journal), (0, stat_out), default_source="output")
+    assert result["/a.py"]["source"] == "output"
+
+
+def test_drain_data_paths_always_use_data_source():
+    """A /data path must always be labeled "data" regardless of the
+    caller's default_source — write_file vs run_file vs skill calls
+    all see the same label for shared-volume files.
+    """
+    journal = "CREATE\t/data/forecast.parquet\t1700000000\n"
+    stat_out = "/data/forecast.parquet|999|1700000000"
+    result, _ = _drain_with_responses((0, journal), (0, stat_out), default_source="agent")
+    # /data files keep their full path as the logical key.
+    assert "/data/forecast.parquet" in result
+    assert result["/data/forecast.parquet"]["source"] == "data"
+
+
+def test_drain_filters_skills_paths():
+    """Events on /skills/ are runtime plumbing and must not leak into
+    state["files"] regardless of how they got recorded."""
+    journal = "CREATE\t/skills/myskill/scripts/fetch.py\t1700000000\nCREATE\t/workspace/real.py\t1700000001\n"
+    stat_out = "/workspace/real.py|10|1700000001"
+    result, _ = _drain_with_responses((0, journal), (0, stat_out))
+    # Only the workspace path survives; skill path is filtered before stat.
+    assert set(result.keys()) == {"/real.py"}
+
+
+def test_drain_drops_paths_that_no_longer_exist():
+    """A file may be created and deleted between the inotify event and
+    the drain (a temp file, for example). When stat fails for that path
+    the entry is dropped silently."""
+    journal = (
+        "CREATE\t/workspace/keeper.py\t1700000000\n"
+        "CREATE\t/workspace/temp.py\t1700000001\n"
+        "DELETE\t/workspace/temp.py\t1700000002\n"
+    )
+    # stat output only includes keeper.py — temp.py is gone.
+    stat_out = "/workspace/keeper.py|42|1700000000"
+    result, _ = _drain_with_responses((0, journal), (0, stat_out))
+    assert set(result.keys()) == {"/keeper.py"}
+
+
+def test_drain_ignores_lines_with_wrong_field_count():
+    """Robustness: malformed journal lines (missing tabs, extra noise)
+    are skipped rather than crashing the drain."""
+    journal = (
+        "CREATE\t/workspace/ok.py\t1700000000\n"
+        "garbage line with no tabs\n"
+        "TWO\tFIELDS\n"
+        "FOUR\tFIELDS\there\there\n"  # 4 fields — splits to 4, not 3
+        "CREATE\t/workspace/also-ok.py\tNOT_A_NUMBER\n"  # bad ts
+    )
+    stat_out = "/workspace/ok.py|1|1700000000"
+    result, _ = _drain_with_responses((0, journal), (0, stat_out))
+    assert set(result.keys()) == {"/ok.py"}
+
+
+def test_drain_drops_events_outside_watched_areas():
+    """Inotify shouldn't watch outside /workspace and /data, but if a
+    rogue event reaches the journal (manual daemon, etc.), the drain's
+    source-mapping rejects it."""
+    journal = "CREATE\t/etc/passwd\t1700000000\nCREATE\t/workspace/legit.py\t1700000001\n"
+    # stat over both paths; even if /etc/passwd exists, drain drops it
+    # at the source-mapping step.
+    stat_out = "/workspace/legit.py|10|1700000001\n/etc/passwd|2000|1700000000"
+    result, _ = _drain_with_responses((0, journal), (0, stat_out))
+    assert set(result.keys()) == {"/legit.py"}
+
+
+def test_drain_workspace_root_collapses_to_slash():
+    """The /workspace mount point itself is mapped to logical path "/"
+    so it doesn't collide with workspace contents."""
+    journal = "CREATE\t/workspace\t1700000000\n"
+    stat_out = "/workspace|0|1700000000"
+    result, _ = _drain_with_responses((0, journal), (0, stat_out))
+    assert "/" in result
+
+
+def test_drain_failed_drain_exec_returns_empty():
+    """If the drain command itself errors (sandbox unreachable, etc.),
+    return an empty dict rather than blowing up the calling tool."""
+    result, _ = _drain_with_responses((1, ""))
+    assert result == {}

--- a/tests/test_sandbox_helpers.py
+++ b/tests/test_sandbox_helpers.py
@@ -23,6 +23,7 @@ from rhiza_agents.agents.tools.sandbox import (
     drain_inotify_journal,
     exec_as_daytona,
     list_workspace_files,
+    start_inotify_daemon,
 )
 
 # ---------------------------------------------------------------------------
@@ -329,6 +330,56 @@ def test_drain_restarts_daemon_when_probe_reports_dead():
     # start fired before the stat exec (it sits between probe and stat).
     # exec calls: [drain, probe], then start, then [stat].
     assert call_order == ["exec", "exec", "start", "exec"]
+
+
+# ---------------------------------------------------------------------------
+# start_inotify_daemon — watch-limit detection parsing (log-only branch)
+# ---------------------------------------------------------------------------
+
+
+def _run_start_with_result(result_text: str):
+    """Invoke start_inotify_daemon with ``exec_as_daytona`` returning a
+    single response whose ``result`` is ``result_text`` (exit 0)."""
+    resp = SimpleNamespace(exit_code=0, result=result_text)
+    with mock.patch(
+        "rhiza_agents.agents.tools.sandbox.exec_as_daytona",
+        return_value=resp,
+    ):
+        start_inotify_daemon(sandbox=object())
+
+
+def test_start_logs_watch_limit_when_detected(caplog):
+    """A daemon-dead result whose stderr mentions the inotify watch limit
+    triggers the specific max_user_watches warning."""
+    dead_with_limit = (
+        "INOTIFY_DEAD\n"
+        "Failed to watch /data; upgrade the inotify watch limit "
+        "(see max_user_watches) or use a smaller tree.\n"
+    )
+    with caplog.at_level("WARNING", logger="rhiza_agents.agents.tools.sandbox"):
+        _run_start_with_result(dead_with_limit)
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "max_user_watches" in joined
+    assert "watch limit" in joined
+
+
+def test_start_does_not_log_watch_limit_for_clean_start(caplog):
+    """A clean INOTIFY_RUNNING result emits no watch-limit warning."""
+    with caplog.at_level("WARNING", logger="rhiza_agents.agents.tools.sandbox"):
+        _run_start_with_result("INOTIFY_RUNNING\n")
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "max_user_watches" not in joined
+    assert "session tracking disabled" not in joined
+
+
+def test_start_logs_generic_dead_without_watch_limit(caplog):
+    """A daemon-dead result with no watch-limit wording logs the generic
+    'exited at startup' warning, not the watch-limit one."""
+    with caplog.at_level("WARNING", logger="rhiza_agents.agents.tools.sandbox"):
+        _run_start_with_result("INOTIFY_DEAD\nsome other failure\n")
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "exited at startup" in joined
+    assert "max_user_watches" not in joined
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sandbox_helpers.py
+++ b/tests/test_sandbox_helpers.py
@@ -22,6 +22,7 @@ from unittest import mock
 from rhiza_agents.agents.tools.sandbox import (
     drain_inotify_journal,
     exec_as_daytona,
+    list_workspace_files,
 )
 
 # ---------------------------------------------------------------------------
@@ -137,10 +138,13 @@ def _drain_with_responses(*responses: tuple[int, str], **kwargs):
     """Invoke drain_inotify_journal with ``exec_as_daytona`` returning the
     given (exit_code, result) responses in order.
 
-    First call is the drain (cat then truncate); second is the stat
-    batch over the surviving paths.
+    The first exec_as_daytona call drain makes is the liveness probe
+    (``pgrep -x inotifywait``); we prepend a success response for it so
+    the daemon is reported alive and no restart fires. The supplied
+    responses then map to the drain (cat + truncate) and the stat batch.
     """
-    fake_responses = [SimpleNamespace(exit_code=ec, result=res) for ec, res in responses]
+    probe = SimpleNamespace(exit_code=0, result="")
+    fake_responses = [probe] + [SimpleNamespace(exit_code=ec, result=res) for ec, res in responses]
     with mock.patch(
         "rhiza_agents.agents.tools.sandbox.exec_as_daytona",
         side_effect=fake_responses,
@@ -256,3 +260,58 @@ def test_drain_failed_drain_exec_returns_empty():
     return an empty dict rather than blowing up the calling tool."""
     result, _ = _drain_with_responses((1, ""))
     assert result == {}
+
+
+def test_drain_handles_tab_in_filename():
+    """A filename with an embedded tab must still be tracked. The path is
+    everything between the event field and the timestamp field, so the
+    tab inside the name does not split the record into the wrong shape."""
+    weird = "/workspace/odd\tname.py"
+    journal = f"CREATE\t{weird}\t1700000000\n"
+    stat_out = f"{weird}|7|1700000000"
+    result, _ = _drain_with_responses((0, journal), (0, stat_out))
+    # Logical key strips the /workspace prefix but keeps the embedded tab.
+    assert "/odd\tname.py" in result
+    assert result["/odd\tname.py"]["size"] == 7
+
+
+# ---------------------------------------------------------------------------
+# list_workspace_files — NUL-separated find parsing
+# ---------------------------------------------------------------------------
+
+
+def _list_with_response(exit_code: int, result: str):
+    class _P:
+        def exec(self, _cmd, **_kwargs):
+            return SimpleNamespace(exit_code=exit_code, result=result)
+
+    sandbox = SimpleNamespace(process=_P())
+    return list_workspace_files(sandbox, "/workspace")
+
+
+def test_list_parses_nul_separated_records():
+    out = "/workspace/a.py\x0010\x001700000000\x00/workspace/b.txt\x0020\x001700000001\x00"
+    files = _list_with_response(0, out)
+    paths = {f["path"] for f in files}
+    assert paths == {"/workspace/a.py", "/workspace/b.txt"}
+
+
+def test_list_handles_tab_in_filename():
+    """A tab in a filename used to be dropped by the TSV split. With
+    NUL-separated records the file is parsed correctly."""
+    weird = "/workspace/odd\tname.py"
+    out = f"{weird}\x00512\x001700000000\x00"
+    files = _list_with_response(0, out)
+    assert len(files) == 1
+    assert files[0]["path"] == weird
+    assert files[0]["size"] == 512
+
+
+def test_list_handles_newline_in_filename():
+    """A newline in a filename also survives — line-based parsing would
+    corrupt it, NUL-separated parsing does not."""
+    weird = "/workspace/two\nlines.py"
+    out = f"{weird}\x001\x001700000000\x00"
+    files = _list_with_response(0, out)
+    assert len(files) == 1
+    assert files[0]["path"] == weird

--- a/tests/test_sandbox_helpers.py
+++ b/tests/test_sandbox_helpers.py
@@ -138,13 +138,21 @@ def _drain_with_responses(*responses: tuple[int, str], **kwargs):
     """Invoke drain_inotify_journal with ``exec_as_daytona`` returning the
     given (exit_code, result) responses in order.
 
-    The first exec_as_daytona call drain makes is the liveness probe
-    (``pgrep -x inotifywait``); we prepend a success response for it so
-    the daemon is reported alive and no restart fires. The supplied
-    responses then map to the drain (cat + truncate) and the stat batch.
+    drain_inotify_journal now drains the journal FIRST, then runs the
+    liveness probe (``pgrep -x inotifywait``), then the stat batch. The
+    first supplied response maps to the drain (cat + truncate); we splice
+    an alive-probe success response in after it so the daemon is reported
+    alive and no restart fires; the remaining supplied responses map to
+    the stat batch. Tests that need the dead-probe / restart branch use
+    ``_drain_with_dead_probe`` instead.
     """
+    supplied = [SimpleNamespace(exit_code=ec, result=res) for ec, res in responses]
     probe = SimpleNamespace(exit_code=0, result="")
-    fake_responses = [probe] + [SimpleNamespace(exit_code=ec, result=res) for ec, res in responses]
+    if supplied:
+        # drain response, then probe (alive), then any stat response.
+        fake_responses = [supplied[0], probe, *supplied[1:]]
+    else:
+        fake_responses = [probe]
     with mock.patch(
         "rhiza_agents.agents.tools.sandbox.exec_as_daytona",
         side_effect=fake_responses,
@@ -273,6 +281,54 @@ def test_drain_handles_tab_in_filename():
     # Logical key strips the /workspace prefix but keeps the embedded tab.
     assert "/odd\tname.py" in result
     assert result["/odd\tname.py"]["size"] == 7
+
+
+def test_drain_restarts_daemon_when_probe_reports_dead():
+    """When the liveness probe reports the daemon dead, the drain must
+    restart it AND must drain the pre-death journal first. The reorder
+    guarantees events recorded before the daemon died are captured
+    before ``start_inotify_daemon`` truncates the journal on restart.
+
+    Exec response order under the reordered drain: (1) drain cat+truncate
+    returns the populated journal, (2) liveness probe reports dead
+    (exit 1), (3) stat batch. ``start_inotify_daemon`` is mocked so its
+    own truncate doesn't run; we assert it was called and that the
+    already-populated journal still produced its entry.
+    """
+    journal = "CREATE\t/workspace/pre_death.py\t1700000000\n"
+    stat_out = "/workspace/pre_death.py|128|1700000000"
+    call_order: list[str] = []
+
+    drain_resp = SimpleNamespace(exit_code=0, result=journal)
+    probe_dead = SimpleNamespace(exit_code=1, result="")
+    stat_resp = SimpleNamespace(exit_code=0, result=stat_out)
+    fake_responses = iter([drain_resp, probe_dead, stat_resp])
+
+    def _fake_exec(_sandbox, _cmd, **_kwargs):
+        call_order.append("exec")
+        return next(fake_responses)
+
+    def _fake_start(_sandbox):
+        call_order.append("start")
+
+    with (
+        mock.patch("rhiza_agents.agents.tools.sandbox.exec_as_daytona", side_effect=_fake_exec),
+        mock.patch("rhiza_agents.agents.tools.sandbox.start_inotify_daemon", side_effect=_fake_start) as start,
+    ):
+        result = drain_inotify_journal(sandbox=object(), default_source="agent")
+
+    # The daemon was restarted because the probe reported it dead.
+    start.assert_called_once()
+    # The pre-death event survived: the drain (cat) ran and was parsed
+    # before the restart would have truncated the journal.
+    assert "/pre_death.py" in result
+    assert result["/pre_death.py"]["size"] == 128
+    # Ordering: the first exec (the drain cat) ran before start_inotify_daemon.
+    assert call_order[0] == "exec"
+    assert call_order.index("start") > 0
+    # start fired before the stat exec (it sits between probe and stat).
+    # exec calls: [drain, probe], then start, then [stat].
+    assert call_order == ["exec", "exec", "start", "exec"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skill_path_validation.py
+++ b/tests/test_skill_path_validation.py
@@ -1,0 +1,179 @@
+"""Tests for _validate_skill_path — the path-safety gate run_file uses
+to reject anything that isn't an installed skill script.
+
+The agent supplies the path to run_file, so any traversal vector here
+becomes a way to execute arbitrary scripts at root privilege via
+exec_skill. The check is the only line of defense between agent input
+and the unwrapped (root-context) exec path.
+"""
+
+import pytest
+
+from rhiza_agents.agents.tools.files import _validate_skill_path
+
+
+def _ok(path: str) -> None:
+    """Assert path is accepted (validation returns None)."""
+    err = _validate_skill_path(path)
+    assert err is None, f"expected {path!r} to be accepted, got error: {err!r}"
+
+
+def _rejected(path: str) -> str:
+    """Assert path is rejected; return the error string for substring checks."""
+    err = _validate_skill_path(path)
+    assert err is not None, f"expected {path!r} to be rejected"
+    return err
+
+
+# --- accepted shapes ---
+
+
+def test_canonical_path_accepted():
+    _ok("/skills/myskill/scripts/fetch.py")
+
+
+def test_deeper_subdirs_under_scripts_accepted():
+    # Skill authors may organize scripts/ into subdirectories.
+    _ok("/skills/myskill/scripts/sub/dir/fetch.py")
+
+
+def test_dotted_skill_name_accepted():
+    _ok("/skills/my.skill/scripts/fetch.py")
+
+
+def test_hyphenated_skill_name_accepted():
+    _ok("/skills/my-skill/scripts/fetch.py")
+
+
+# --- prefix rejections ---
+
+
+def test_outside_skills_rejected():
+    err = _rejected("/foo.py")
+    assert "Path must be under /skills/" in err
+
+
+def test_workspace_path_rejected():
+    err = _rejected("/workspace/code/foo.py")
+    assert "Path must be under /skills/" in err
+
+
+def test_data_path_rejected():
+    err = _rejected("/data/forecast.parquet")
+    assert "Path must be under /skills/" in err
+
+
+def test_skills_directory_itself_rejected():
+    # No trailing slash — doesn't start with "/skills/".
+    err = _rejected("/skills")
+    assert "Path must be under /skills/" in err
+
+
+def test_skill_name_no_scripts_subdir_rejected():
+    err = _rejected("/skills/myskill")
+    assert "Path must be under /skills/" not in err  # passes prefix
+    assert "/skills/<name>/scripts/<file>" in err
+
+
+# --- traversal rejections ---
+
+
+def test_dotdot_in_filename_rejected():
+    err = _rejected("/skills/myskill/scripts/../etc/passwd")
+    assert "may not contain '..'" in err
+
+
+def test_dotdot_at_top_rejected():
+    err = _rejected("/skills/../../etc/passwd")
+    assert "may not contain '..'" in err
+
+
+def test_single_dotdot_segment_rejected():
+    err = _rejected("/skills/myskill/scripts/..")
+    assert "may not contain '..'" in err
+
+
+def test_dotdot_inside_filename_string_accepted():
+    # `..` only matches when it's a full path segment. A filename
+    # like `foo..bar.py` is a perfectly normal filename.
+    _ok("/skills/myskill/scripts/foo..bar.py")
+
+
+# --- consecutive-slash rejections ---
+
+
+def test_double_slash_after_skills_rejected():
+    err = _rejected("/skills//scripts/x.py")
+    assert "consecutive slashes" in err
+
+
+def test_double_slash_in_skill_name_rejected():
+    err = _rejected("/skills/foo//scripts/x.py")
+    assert "consecutive slashes" in err
+
+
+def test_double_slash_before_filename_rejected():
+    err = _rejected("/skills/foo/scripts//x.py")
+    assert "consecutive slashes" in err
+
+
+# --- shape mismatch rejections ---
+
+
+def test_third_segment_must_be_scripts():
+    err = _rejected("/skills/myskill/notscripts/x.py")
+    assert "<name>/scripts/<file>" in err
+
+
+def test_only_two_segments_rejected():
+    err = _rejected("/skills/myskill/")
+    # Trailing slash — split yields ['skills','myskill',''] — length 3,
+    # parts[2] is '' (not 'scripts'). The shape check fires.
+    assert "<name>/scripts/<file>" in err
+
+
+def test_three_segments_no_file_rejected():
+    err = _rejected("/skills/myskill/scripts")
+    assert "<name>/scripts/<file>" in err
+
+
+def test_trailing_slash_after_scripts_rejected():
+    err = _rejected("/skills/myskill/scripts/")
+    # split yields ['skills','myskill','scripts',''] — len 4, parts[2]
+    # OK, but parts[-1] is empty.
+    assert "empty segment" in err
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/skills/myskill/scripts/sub/foo.py",
+        "/skills/a/scripts/b/c/d/e.py",
+        "/skills/123/scripts/run.py",
+    ],
+)
+def test_valid_paths_parametrized(path):
+    _ok(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/skills/myskill/scripts/../../etc/shadow",
+        "/skills//myskill/scripts/x.py",
+        "/skills/myskill//scripts/x.py",
+        "/skills/myskill/scripts//x.py",
+        "/skills/myskill/scripts/.../foo.py",  # ... is not .. but contains no path traversal
+        "/skills/myskill/scripts",
+        "/skills/myskill",
+        "/skills/",
+        "/etc/passwd",
+        "",
+    ],
+)
+def test_clearly_unsafe_paths_rejected(path):
+    if path == "/skills/myskill/scripts/.../foo.py":
+        # Three-dot directory is not a path-traversal vector — accept.
+        _ok(path)
+        return
+    assert _validate_skill_path(path) is not None, f"{path!r} should be rejected"

--- a/tests/test_skills_activation.py
+++ b/tests/test_skills_activation.py
@@ -107,6 +107,43 @@ def _activate(tool, state=None):
     return asyncio.run(tool.coroutine(runtime=runtime))
 
 
+class _FakeSandbox:
+    """Minimal sandbox stand-in that records process.exec calls.
+
+    Used to verify the skill activation install commands without
+    needing a real Daytona sandbox. exec calls return a successful
+    response so the activation flow runs to completion.
+    """
+
+    def __init__(self):
+        self.exec_calls: list[str] = []
+
+        class _Process:
+            def exec(inner_self, cmd, **kwargs):  # noqa: N805 — match SDK signature
+                self.exec_calls.append(cmd)
+                return SimpleNamespace(exit_code=0, result="")
+
+        self.process = _Process()
+
+
+def _activate_with_sandbox(tool):
+    """Activate with sandbox available; return (Command, FakeSandbox).
+
+    Patches the real is_sandbox_available + _get_or_create_sandbox so
+    activation goes down the install-to-/skills/ path. The FakeSandbox
+    records every process.exec command issued.
+    """
+    from unittest import mock
+
+    fake = _FakeSandbox()
+    with (
+        mock.patch("rhiza_agents.agents.tools.sandbox.is_sandbox_available", return_value=True),
+        mock.patch("rhiza_agents.agents.tools.sandbox._get_or_create_sandbox", return_value=fake),
+    ):
+        cmd = _activate(tool)
+    return cmd, fake
+
+
 def test_tool_name_and_description():
     tool = create_skill_tool(_record())
     assert tool.name == "skill_hello_skill"
@@ -134,29 +171,35 @@ def test_activation_command_no_scripts_has_only_messages():
     assert "# Hello" in msg.content
 
 
-def test_activation_command_loads_scripts_into_files():
+def test_activation_installs_scripts_via_process_exec():
+    """Skill scripts are installed under /skills/<name>/scripts/ via
+    shell commands (mkdir, base64 decode, chown, chmod). They do NOT
+    appear in state["files"] — skill code does not belong in
+    conversation state.
+    """
     tool = create_skill_tool(_record(scripts={"fetch.py": "print('hi')\n", "plot.py": "print('bye')"}))
-    cmd = _activate(tool)
-    files = cmd.update["files"]
-    # Paths are namespaced under /skills/<skill-name>/scripts so that
-    # multiple skills shipping the same filename (e.g. four fetchers each
-    # with a fetch.py) don't collide in the file state.
-    assert set(files.keys()) == {
-        "/skills/hello-skill/scripts/fetch.py",
-        "/skills/hello-skill/scripts/plot.py",
-    }
-    # Stored as a list of lines, matching write_file's shape.
-    assert files["/skills/hello-skill/scripts/fetch.py"]["content"] == ["print('hi')", ""]
-    assert files["/skills/hello-skill/scripts/plot.py"]["content"] == ["print('bye')"]
-    # Metadata stamped for provenance.
-    for entry in files.values():
-        assert entry["source"] == "skill"
-        assert entry["skill_id"] == "sk-test"
-        assert "created_at" in entry and "modified_at" in entry
+    cmd, fake = _activate_with_sandbox(tool)
+
+    # State["files"] is not used for skill scripts.
+    assert "files" not in cmd.update
+
+    # Each script's install command landed at the namespaced path with
+    # the right ownership and mode applied.
+    joined = "\n".join(fake.exec_calls)
+    for filename in ("fetch.py", "plot.py"):
+        path = f"/skills/hello-skill/scripts/{filename}"
+        assert path in joined, f"install command missing for {path}: {fake.exec_calls!r}"
+    # Files end up root-owned and read-only-to-non-root via chmod 0644.
+    assert "chown root:root" in joined
+    assert "chmod 0644" in joined
 
 
 def test_activation_namespaces_by_skill_name():
-    """Two skills with a filename collision must not stomp each other."""
+    """Two skills with a filename collision must not stomp each other.
+
+    The install commands target /skills/<skill-name>/scripts/<file>,
+    so each skill's fetch.py lands at a distinct path.
+    """
     ecmwf = create_skill_tool(
         {
             "id": "sk-ecmwf",
@@ -171,21 +214,47 @@ def test_activation_namespaces_by_skill_name():
             "scripts_json": {"fetch.py": "print('chirps')"},
         }
     )
-    e_files = _activate(ecmwf).update["files"]
-    c_files = _activate(chirps).update["files"]
-    assert "/skills/ecmwf-fetch/scripts/fetch.py" in e_files
-    assert "/skills/chirps-fetch/scripts/fetch.py" in c_files
-    # Crucially they land at distinct paths so activating both in the same
-    # conversation keeps both scripts available.
-    assert set(e_files).isdisjoint(set(c_files))
+    _, e_fake = _activate_with_sandbox(ecmwf)
+    _, c_fake = _activate_with_sandbox(chirps)
+    e_joined = "\n".join(e_fake.exec_calls)
+    c_joined = "\n".join(c_fake.exec_calls)
+    assert "/skills/ecmwf-fetch/scripts/fetch.py" in e_joined
+    assert "/skills/chirps-fetch/scripts/fetch.py" in c_joined
+    # The other skill's path must NOT appear in the corresponding
+    # exec stream — namespacing keeps them disjoint.
+    assert "/skills/chirps-fetch/scripts/fetch.py" not in e_joined
+    assert "/skills/ecmwf-fetch/scripts/fetch.py" not in c_joined
 
 
 def test_activation_preserves_script_content_passed_as_list():
-    # If the DB serializer ever stores content pre-split, we should still
-    # round-trip without double-splitting or mangling.
+    """If scripts_json stores content pre-split as a list of lines,
+    activation should still install the joined content."""
+    import base64
+
     tool = create_skill_tool(_record(scripts={"a.py": ["line1", "line2"]}))
-    cmd = _activate(tool)
-    assert cmd.update["files"]["/skills/hello-skill/scripts/a.py"]["content"] == ["line1", "line2"]
+    _, fake = _activate_with_sandbox(tool)
+    # The install command base64-encodes the content; decode it and
+    # check the install actually carried "line1\nline2".
+    expected_b64 = base64.b64encode(b"line1\nline2").decode("ascii")
+    joined = "\n".join(fake.exec_calls)
+    assert expected_b64 in joined, f"expected base64 of joined lines in exec calls: {fake.exec_calls!r}"
+
+
+def test_activation_no_sandbox_emits_error_message():
+    """When DAYTONA_API_KEY is unset, activation can't install scripts.
+
+    The activation message still emits the prompt, but a follow-up
+    error ToolMessage tells the agent the install was skipped. State
+    is not touched (the legacy fallback that wrote skill content to
+    state was removed — skills don't belong in state).
+    """
+    tool = create_skill_tool(_record(scripts={"fetch.py": "pass"}))
+    cmd = _activate(tool)  # No sandbox patching; is_sandbox_available -> False
+    assert "files" not in cmd.update
+    msgs = cmd.update["messages"]
+    assert len(msgs) == 2  # prompt + error
+    assert "DAYTONA_API_KEY not set" in msgs[1].content
+    assert msgs[1].status == "error"
 
 
 def test_activation_tool_message_names_every_script():

--- a/tests/test_workspace_path_safety.py
+++ b/tests/test_workspace_path_safety.py
@@ -79,6 +79,39 @@ def test_dot_segments_within_data_allowed():
 
 
 # ---------------------------------------------------------------------------
+# Cross-volume aliasing: a /data input must stay under /data, a workspace
+# input must stay under /workspace. A path that lexically normalizes into
+# the other root must be rejected, not silently re-rooted, so the
+# state["files"] key namespace stays consistent.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "logical",
+    [
+        "/data/../workspace/x",
+        "/data/../../workspace/x",
+        "/data/sub/../../workspace/y",
+    ],
+)
+def test_data_input_resolving_into_workspace_rejected(logical):
+    with pytest.raises(ValueError):
+        workspace_path(logical)
+
+
+@pytest.mark.parametrize(
+    "logical",
+    [
+        "/../data/x",
+        "/sub/../../data/y",
+    ],
+)
+def test_workspace_input_resolving_into_data_rejected(logical):
+    with pytest.raises(ValueError):
+        workspace_path(logical)
+
+
+# ---------------------------------------------------------------------------
 # Symlink-escape guard (in-sandbox realpath check).
 #
 # workspace_path's normpath is lexical; it cannot see a symlink the agent

--- a/tests/test_workspace_path_safety.py
+++ b/tests/test_workspace_path_safety.py
@@ -9,12 +9,16 @@ would otherwise normalize to a root-owned file outside /workspace and
 without any root-level filesystem access.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from rhiza_agents.agents.tools.sandbox import (
     SANDBOX_DATA,
     SANDBOX_WORKSPACE,
+    read_workspace_file,
     workspace_path,
+    write_workspace_file,
 )
 
 
@@ -72,3 +76,75 @@ def test_dot_segments_within_workspace_allowed():
 
 def test_dot_segments_within_data_allowed():
     assert workspace_path("/data/sub/../forecast.parquet") == f"{SANDBOX_DATA}/forecast.parquet"
+
+
+# ---------------------------------------------------------------------------
+# Symlink-escape guard (in-sandbox realpath check).
+#
+# workspace_path's normpath is lexical; it cannot see a symlink the agent
+# planted in the sandbox FS via HITL-approved execute_python_code. The
+# read/write helpers resolve the real path in-sandbox via ``realpath -m``
+# and reject anything that resolves outside /workspace or /data, before
+# any read or write runs.
+# ---------------------------------------------------------------------------
+
+
+class _RealpathSandbox:
+    """Sandbox stub: answers ``realpath -m`` with a fixed escaped target,
+    and records every other exec so we can assert no read/write fired."""
+
+    def __init__(self, realpath_result: str, realpath_exit: int = 0):
+        self._realpath_result = realpath_result
+        self._realpath_exit = realpath_exit
+        self.exec_calls: list[str] = []
+
+        class _P:
+            def exec(p_self, cmd, **_kwargs):  # noqa: N805
+                self.exec_calls.append(cmd)
+                if cmd.startswith("realpath"):
+                    return SimpleNamespace(exit_code=self._realpath_exit, result=self._realpath_result)
+                # Any non-realpath exec (the actual read/write) — should
+                # not be reached when the guard rejects.
+                return SimpleNamespace(exit_code=0, result="")
+
+        self.process = _P()
+
+
+def test_read_rejects_symlink_escape_no_read_exec():
+    # realpath resolves the file to a target outside the roots → reject
+    # before the base64 read exec runs.
+    sandbox = _RealpathSandbox(realpath_result="/etc/passwd")
+    with pytest.raises(ValueError):
+        read_workspace_file(sandbox, f"{SANDBOX_WORKSPACE}/evil_link")
+    # Only the realpath probe ran; the read (test -f / base64) never did.
+    assert len(sandbox.exec_calls) == 1
+    assert sandbox.exec_calls[0].startswith("realpath")
+
+
+def test_write_rejects_symlink_escape_no_write_exec():
+    # realpath of the parent dir resolves outside the roots → reject
+    # before mkdir/base64 write runs.
+    sandbox = _RealpathSandbox(realpath_result="/etc")
+    with pytest.raises(ValueError):
+        write_workspace_file(sandbox, f"{SANDBOX_WORKSPACE}/sub/evil", b"data")
+    assert len(sandbox.exec_calls) == 1
+    assert sandbox.exec_calls[0].startswith("realpath")
+
+
+def test_read_allows_contained_realpath():
+    # A realpath that stays under /workspace passes the guard; the read
+    # exec then runs (returns empty here → FileNotFoundError path).
+    sandbox = _RealpathSandbox(realpath_result=f"{SANDBOX_WORKSPACE}/real.py")
+
+    class _OkExec:
+        def exec(self, cmd, **_kwargs):
+            sandbox.exec_calls.append(cmd)
+            if cmd.startswith("realpath"):
+                return SimpleNamespace(exit_code=0, result=f"{SANDBOX_WORKSPACE}/real.py")
+            # base64 read returns content.
+            import base64 as _b64
+
+            return SimpleNamespace(exit_code=0, result=_b64.b64encode(b"hello").decode())
+
+    sandbox.process = _OkExec()
+    assert read_workspace_file(sandbox, f"{SANDBOX_WORKSPACE}/real.py") == b"hello"

--- a/tests/test_workspace_path_safety.py
+++ b/tests/test_workspace_path_safety.py
@@ -1,0 +1,74 @@
+"""Tests for workspace_path's traversal guard.
+
+workspace_path is the single choke point that maps a logical file path
+(as supplied by the file-viewer endpoint, ultimately from a URL path
+segment) to the absolute sandbox path that read_workspace_file /
+write_workspace_file run as root. A logical path with ``..`` segments
+would otherwise normalize to a root-owned file outside /workspace and
+/data; the guard rejects it with ValueError so the route returns 404
+without any root-level filesystem access.
+"""
+
+import pytest
+
+from rhiza_agents.agents.tools.sandbox import (
+    SANDBOX_DATA,
+    SANDBOX_WORKSPACE,
+    workspace_path,
+)
+
+
+def test_plain_workspace_path_maps_under_workspace():
+    assert workspace_path("/foo.py") == f"{SANDBOX_WORKSPACE}/foo.py"
+
+
+def test_nested_workspace_path():
+    assert workspace_path("/sub/dir/bar.csv") == f"{SANDBOX_WORKSPACE}/sub/dir/bar.csv"
+
+
+def test_data_path_kept_as_is():
+    assert workspace_path("/data/forecast.parquet") == f"{SANDBOX_DATA}/forecast.parquet"
+
+
+def test_data_root_kept_as_is():
+    assert workspace_path("/data") == SANDBOX_DATA
+
+
+@pytest.mark.parametrize(
+    "logical",
+    [
+        "/../etc/passwd",
+        "/../../etc/passwd",
+        "/sub/../../etc/passwd",
+        "/foo/../../bar",
+    ],
+)
+def test_workspace_traversal_rejected(logical):
+    # Escapes /workspace via .. segments — must raise, not resolve to a
+    # root-owned file the read/write helpers would touch as root.
+    with pytest.raises(ValueError):
+        workspace_path(logical)
+
+
+@pytest.mark.parametrize(
+    "logical",
+    [
+        "/data/../../etc/x",
+        "/data/../etc/passwd",
+        "/data/sub/../../../etc/passwd",
+    ],
+)
+def test_data_traversal_rejected(logical):
+    # The /data prefix must be protected too: /data/../../etc/x escapes
+    # the data root and must be rejected.
+    with pytest.raises(ValueError):
+        workspace_path(logical)
+
+
+def test_dot_segments_within_workspace_allowed():
+    # A .. that stays within /workspace normalizes cleanly and is fine.
+    assert workspace_path("/sub/../foo.py") == f"{SANDBOX_WORKSPACE}/foo.py"
+
+
+def test_dot_segments_within_data_allowed():
+    assert workspace_path("/data/sub/../forecast.parquet") == f"{SANDBOX_DATA}/forecast.parquet"


### PR DESCRIPTION
## Summary

Implements the design in #31 — persistent per-conversation `/workspace`, shared `/data` volume, non-root agent execution, and skill-script tamper protection. The spec body has known divergences (deferred requirements + design changes during implementation); see the [implementation-drift comment](https://github.com/rhiza-research/rhiza-agents/issues/31#issuecomment-4339741887) on the spec issue for the full delta and rationale.

Headline changes:

- **Storage:** `/workspace` (per-conversation subpath of homes volume), `/data` (shared volume across conversations). Configured via `DAYTONA_HOMES_VOLUME` / `DAYTONA_DATA_VOLUME` env vars (and matching `*_MOUNT_PATH` overrides).
- **Trust model:** agent runs as non-root `daytona` via `su -l` wrapping every agent-driven `process.exec`. Skill scripts at `/skills/<name>/scripts/<file>` are root-owned mode 0644 on the regular container FS — agent reads + executes via `run_file` but cannot modify (POSIX permissions enforce). `run_file` rejects any path not under `/skills/`. `write_file` is commented out; agent has no direct file-write tool.
- **Session tracking:** per-sandbox `inotifywait` daemon watches `/workspace` and `/data`; drained into `state["files"]` (path-only metadata) after each agent tool call.
- **Conversation deletion:** UI button per row; backend DELETE endpoint now does an explicit ownership check before any side effects (was a silent SQL no-op for non-owners that still cleaned up the owner's sandbox); homes-volume subpath cleanup hooked into delete.
- **Lazy migration:** legacy state-stored content materializes to the workspace volume on first access via `run_file` or `fetch_file_content`.

Deferred (platform constraints, see drift comment): library cache persistence (mountpoint-s3 doesn't support uv/pip rename ops), filesystem-enforced read-only on `/workspace` and `/data` (mountpoint-s3 rejects chown/chmod). The residual tamper surface is `execute_python_code` writes to those volumes, mediated by HITL approval; documented in `make_execute_python_code`'s docstring.

## Test plan

- [x] `uv run pytest` — 127 tests pass locally
- [ ] Frontend builds cleanly: from `frontend/`, run `npm run build` — produces `app.js` / `app.css`
- [ ] Set `DAYTONA_HOMES_VOLUME` and `DAYTONA_DATA_VOLUME` in `.envrc`
- [ ] `podman compose up -d`
- [ ] Send a chat message; activate a skill that bundles a script; run it via `run_file`
- [ ] Verify file panel session view shows files the skill wrote, with the right source labels (`data`, `output`)
- [ ] Toggle to "All files" — confirm live listing of `/workspace` and `/data` works
- [ ] Click a file — confirm content fetch via the file viewer endpoint (lazy-creates sandbox if not running)
- [ ] Try `run_file("/workspace/foo.py")` from the agent — confirm rejection
- [ ] Delete a conversation from the sidebar — confirm sandbox killed and homes-volume subpath cleaned
- [ ] Open a shared conversation URL as a different user — confirm read-only file viewing works, delete button absent
